### PR TITLE
[Feat] 총 지출 상세 내역 바텀 모달 시트 인터렉션 개발

### DIFF
--- a/snapsplit/src/app/layout.tsx
+++ b/snapsplit/src/app/layout.tsx
@@ -26,6 +26,7 @@ export default function RootLayout({
         content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no,viewport-fit=cover"
       />
       <body className="h-[100dvh] min-w-[360px] max-w-[415px] lg:max-w-[360px] mx-auto bg-white text-grey-1000 scroll-smooth">
+        <div id="modal-root" />
         {children}
       </body>
     </html>

--- a/snapsplit/src/features/trip/[tripId]/TripPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/TripPage.tsx
@@ -97,13 +97,13 @@ export default async function TripPage({ params }: { params: { tripId: number } 
       <DailyExpenseList expenses={expenses} tripStartDate="2025-04-07" tripEndDate="2025-04-16" />
 
       {/* 고정 바텀 시트 */}
-      <BottomSheetWrapper>
+      {/* <BottomSheetWrapper>
         <TotalExpenseBottomSheet tripTotalExpense={1355200} />
-      </BottomSheetWrapper>
+      </BottomSheetWrapper> */}
+      <BottomSheetTrigger total={1355200} />
 
       {/* 고정 네비게이션 바 */}
-      {/* <BottomNavBar /> */}
-      <BottomSheetTrigger total={1355200} />
+      <BottomNavBar />
     </div>
   );
 }

--- a/snapsplit/src/features/trip/[tripId]/TripPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/TripPage.tsx
@@ -4,7 +4,7 @@ import DailyExpenseList from './_components/DailyExpenseList';
 import ExpenseFilter from './_components/ExpenseFilter';
 import SharedBudgetBar from './_components/SharedBudgetBar';
 import TotalExpenseBottomSheet from './_components/TotalExpenseBottomSheet';
-import TripDateFilterBar from './_components/TripDateFilterBar';
+import TripDateBar from './_components/TripDateBar';
 import TripHeader from './_components/TripHeader';
 
 export default async function TripPage({ params }: { params: { tripId: number } }) {
@@ -87,7 +87,7 @@ export default async function TripPage({ params }: { params: { tripId: number } 
           endDate={'4.12'}
         />
         <SharedBudgetBar totalShared={totalShared} />
-        <TripDateFilterBar startDate={'2025-4-7'} endDate={'2025-4-16'} />
+        <TripDateBar startDate="2025-04-07" endDate="2025-04-16" />
       </div>
 
       {/* 지출 리스트: 가능한 영역만 차지 + 스크롤 */}

--- a/snapsplit/src/features/trip/[tripId]/TripPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/TripPage.tsx
@@ -6,6 +6,7 @@ import SharedBudgetBar from './_components/SharedBudgetBar';
 import TotalExpenseBottomSheet from './_components/TotalExpenseBottomSheet';
 import TripDateBar from './_components/TripDateBar';
 import TripHeader from './_components/TripHeader';
+import BottomSheetWrapper from './_components/BottomSheetWrapper';
 
 export default async function TripPage({ params }: { params: { tripId: number } }) {
   const tripId = params.tripId;
@@ -95,7 +96,9 @@ export default async function TripPage({ params }: { params: { tripId: number } 
       <DailyExpenseList expenses={expenses} tripStartDate="2025-04-07" tripEndDate="2025-04-16" />
 
       {/* 고정 바텀 시트 */}
-      <TotalExpenseBottomSheet />
+      <BottomSheetWrapper>
+        <TotalExpenseBottomSheet tripTotalExpense={1355200} />
+      </BottomSheetWrapper>
 
       {/* 고정 네비게이션 바 */}
       <BottomNavBar />

--- a/snapsplit/src/features/trip/[tripId]/TripPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/TripPage.tsx
@@ -91,18 +91,9 @@ export default async function TripPage({ params }: { params: { tripId: number } 
         <SharedBudgetBar totalShared={totalShared} />
         <TripDateBar startDate="2025-04-07" endDate="2025-04-16" />
       </div>
-
-      {/* 지출 리스트: 가능한 영역만 차지 + 스크롤 */}
       <ExpenseFilter />
       <DailyExpenseList expenses={expenses} tripStartDate="2025-04-07" tripEndDate="2025-04-16" />
-
-      {/* 고정 바텀 시트 */}
-      {/* <BottomSheetWrapper>
-        <TotalExpenseBottomSheet tripTotalExpense={1355200} />
-      </BottomSheetWrapper> */}
       <BottomSheetTrigger total={1355200} />
-
-      {/* 고정 네비게이션 바 */}
       <BottomNavBar />
     </div>
   );

--- a/snapsplit/src/features/trip/[tripId]/TripPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/TripPage.tsx
@@ -7,6 +7,7 @@ import TotalExpenseBottomSheet from './_components/TotalExpenseBottomSheet';
 import TripDateBar from './_components/TripDateBar';
 import TripHeader from './_components/TripHeader';
 import BottomSheetWrapper from './_components/BottomSheetWrapper';
+import BottomSheetTrigger from './_components/modal/BottomSheetTrigger';
 
 export default async function TripPage({ params }: { params: { tripId: number } }) {
   const tripId = params.tripId;
@@ -101,7 +102,8 @@ export default async function TripPage({ params }: { params: { tripId: number } 
       </BottomSheetWrapper>
 
       {/* 고정 네비게이션 바 */}
-      <BottomNavBar />
+      {/* <BottomNavBar /> */}
+      <BottomSheetTrigger total={1355200} />
     </div>
   );
 }

--- a/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
@@ -24,15 +24,23 @@ const BottomSheetWrapper = ({ children }: Props) => {
   }, [y]);
 
   const handleDragEnd = (_: any, info: any) => {
-    const draggedY = info.offset.y;
-    const draggedRatio = Math.abs(draggedY) / window.innerHeight;
+    const offsetY = info.offset.y; // 얼마나 움직였는지
+    const velocityY = info.velocity.y; // 드래그 속도
+    const screenHeight = window.innerHeight;
 
-    if (draggedRatio > 0.3) {
-      // 전체 열기
+    const draggedRatio = Math.abs(offsetY) / screenHeight;
+
+    const shouldOpen = offsetY < 0 && draggedRatio > 0.1; // 위로 충분히 올린 경우
+    const shouldClose = offsetY > 0 || velocityY > 500; // 아래로 내리거나 빠르게 튕긴 경우
+
+    if (shouldOpen) {
       animate(y, dragRange.top, { type: 'spring', stiffness: 300 });
-    } else {
-      // 다시 내리기
+    } else if (shouldClose) {
       animate(y, 0, { type: 'spring', stiffness: 300 });
+    } else {
+      // 작은 흔들림이면 유지
+      const currentY = y.get();
+      animate(y, currentY, { type: 'spring', stiffness: 300 });
     }
   };
 

--- a/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState, useEffect } from 'react';
+import { useRef, useEffect } from 'react';
 import { useMotionValue, animate, motion } from 'framer-motion';
 
 type Props = {
@@ -10,33 +10,35 @@ type Props = {
 const BottomSheetWrapper = ({ children }: Props) => {
   const y = useMotionValue(0);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [dragRange, setDragRange] = useState({ top: -300, bottom: 0 }); // 초기값은 임의로 세팅
+
+  // drag 범위와 화면 높이 캐싱
+  const dragRangeRef = useRef({ top: -300, bottom: 0 });
+  const screenHeightRef = useRef<number>(0);
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const height = window.innerHeight;
-      const topLimit = -height * 0.7; // 위로 최대 70% 까지 올리게
-      setDragRange({ top: topLimit, bottom: 0 });
+      screenHeightRef.current = height;
 
-      // 바텀시트 초기 위치 세팅
-      y.set(0); // 시작 위치가 0이 아니라면 조정 가능
+      const topLimit = -height * 0.7;
+      dragRangeRef.current = { top: topLimit, bottom: 0 };
+
+      y.set(0); // 초기 위치 설정
     }
   }, [y]);
 
   const handleDragEnd = (_: any, info: any) => {
     const offsetY = info.offset.y;
     const velocityY = info.velocity.y;
-    const screenHeight = window.innerHeight;
 
-    const draggedRatio = Math.abs(offsetY) / screenHeight;
+    const draggedRatio = Math.abs(offsetY) / screenHeightRef.current;
 
     const shouldOpen = offsetY < 0 && draggedRatio > 0.1;
     const shouldClose = offsetY > 0 && (draggedRatio > 0.1 || velocityY > 500);
 
     if (shouldOpen) {
-      animate(y, dragRange.top, { type: 'spring', stiffness: 300 });
+      animate(y, dragRangeRef.current.top, { type: 'spring', stiffness: 300 });
     } else {
-      // 나머지는 모두 닫힘 (이전 상태 유지 X)
       animate(y, 0, { type: 'spring', stiffness: 300 });
     }
   };
@@ -44,7 +46,7 @@ const BottomSheetWrapper = ({ children }: Props) => {
   return (
     <motion.div
       drag="y"
-      dragConstraints={dragRange}
+      dragConstraints={dragRangeRef.current}
       style={{ y }}
       onDragEnd={handleDragEnd}
       className="fixed bottom-10 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] lg:max-w-[360px] mx-auto z-50 touch-none"

--- a/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useRef, useState, useEffect } from 'react';
+import { useMotionValue, animate, motion } from 'framer-motion';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const BottomSheetWrapper = ({ children }: Props) => {
+  const y = useMotionValue(0);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [dragRange, setDragRange] = useState({ top: -300, bottom: 0 }); // 초기값은 임의로 세팅
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const height = window.innerHeight;
+      const topLimit = -height * 0.7; // 위로 최대 70% 까지 올리게
+      setDragRange({ top: topLimit, bottom: 0 });
+
+      // 바텀시트 초기 위치 세팅
+      y.set(0); // 시작 위치가 0이 아니라면 조정 가능
+    }
+  }, [y]);
+
+  const handleDragEnd = (_: any, info: any) => {
+    const draggedY = info.offset.y;
+    const draggedRatio = Math.abs(draggedY) / window.innerHeight;
+
+    if (draggedRatio > 0.3) {
+      // 전체 열기
+      animate(y, dragRange.top, { type: 'spring', stiffness: 300 });
+    } else {
+      // 다시 내리기
+      animate(y, 0, { type: 'spring', stiffness: 300 });
+    }
+  };
+
+  return (
+    <motion.div
+      drag="y"
+      dragConstraints={dragRange}
+      style={{ y }}
+      onDragEnd={handleDragEnd}
+      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] z-50 touch-none"
+      ref={containerRef}
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default BottomSheetWrapper;

--- a/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
@@ -47,7 +47,7 @@ const BottomSheetWrapper = ({ children }: Props) => {
       dragConstraints={dragRange}
       style={{ y }}
       onDragEnd={handleDragEnd}
-      className="fixed bottom-10 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] lg:max-w-[360px] pb-[58px] mx-auto z-50 touch-none"
+      className="fixed bottom-10 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] lg:max-w-[360px] mx-auto z-50 touch-none"
       ref={containerRef}
     >
       {children}

--- a/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/BottomSheetWrapper.tsx
@@ -24,23 +24,20 @@ const BottomSheetWrapper = ({ children }: Props) => {
   }, [y]);
 
   const handleDragEnd = (_: any, info: any) => {
-    const offsetY = info.offset.y; // 얼마나 움직였는지
-    const velocityY = info.velocity.y; // 드래그 속도
+    const offsetY = info.offset.y;
+    const velocityY = info.velocity.y;
     const screenHeight = window.innerHeight;
 
     const draggedRatio = Math.abs(offsetY) / screenHeight;
 
-    const shouldOpen = offsetY < 0 && draggedRatio > 0.1; // 위로 충분히 올린 경우
-    const shouldClose = offsetY > 0 || velocityY > 500; // 아래로 내리거나 빠르게 튕긴 경우
+    const shouldOpen = offsetY < 0 && draggedRatio > 0.1;
+    const shouldClose = offsetY > 0 && (draggedRatio > 0.1 || velocityY > 500);
 
     if (shouldOpen) {
       animate(y, dragRange.top, { type: 'spring', stiffness: 300 });
-    } else if (shouldClose) {
-      animate(y, 0, { type: 'spring', stiffness: 300 });
     } else {
-      // 작은 흔들림이면 유지
-      const currentY = y.get();
-      animate(y, currentY, { type: 'spring', stiffness: 300 });
+      // 나머지는 모두 닫힘 (이전 상태 유지 X)
+      animate(y, 0, { type: 'spring', stiffness: 300 });
     }
   };
 
@@ -50,7 +47,7 @@ const BottomSheetWrapper = ({ children }: Props) => {
       dragConstraints={dragRange}
       style={{ y }}
       onDragEnd={handleDragEnd}
-      className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] z-50 touch-none"
+      className="fixed bottom-10 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] lg:max-w-[360px] pb-[58px] mx-auto z-50 touch-none"
       ref={containerRef}
     >
       {children}

--- a/snapsplit/src/features/trip/[tripId]/_components/DailyExpenseList.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/DailyExpenseList.tsx
@@ -16,7 +16,7 @@ const DailyExpenseList = ({ expenses, tripStartDate, tripEndDate }: DailyExpense
   return (
     <div
       id="scroll-target-top"
-      className="flex-grow w-full space-y-8 px-5 text-grey-850 pb-6 overflow-y-auto scrollbar-hide"
+      className="flex-grow w-full space-y-8 px-5 text-grey-850 pb-[100px] overflow-y-auto scrollbar-hide"
     >
       {groupedExpenses.map((group) => (
         <div key={group.label} className="space-y-3" id={`day-${group.id}`}>

--- a/snapsplit/src/features/trip/[tripId]/_components/DailyExpenseList.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/DailyExpenseList.tsx
@@ -14,9 +14,12 @@ const DailyExpenseList = ({ expenses, tripStartDate, tripEndDate }: DailyExpense
   const groupedExpenses = groupExpensesByDate(expenses, tripStartDate, tripEndDate);
 
   return (
-    <div className="flex-grow w-full space-y-8 px-5 text-grey-850 pb-6 overflow-y-auto scrollbar-hide">
+    <div
+      id="scroll-target-top"
+      className="flex-grow w-full space-y-8 px-5 text-grey-850 pb-6 overflow-y-auto scrollbar-hide"
+    >
       {groupedExpenses.map((group) => (
-        <div key={group.label} className="space-y-3">
+        <div key={group.label} className="space-y-3" id={`day-${group.id}`}>
           <ExpenseDateBar expenseDay={group.label} type={group.type} dayIndex={group.dayIndex} />
           {group.expenses.map((expense) => (
             <ExpenseItem key={`${expense.expenseId}-${expense.expenseCurrency}`} expense={expense} />

--- a/snapsplit/src/features/trip/[tripId]/_components/DailyExpenseList.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/DailyExpenseList.tsx
@@ -19,7 +19,7 @@ const DailyExpenseList = ({ expenses, tripStartDate, tripEndDate }: DailyExpense
       className="flex-grow w-full space-y-8 px-5 text-grey-850 pb-[100px] overflow-y-auto scrollbar-hide"
     >
       {groupedExpenses.map((group) => (
-        <div key={group.label} className="space-y-3" id={`day-${group.id}`}>
+        <div key={group.label} className="space-y-3" id={group.id ? `day-${group.id}` : undefined}>
           <ExpenseDateBar expenseDay={group.label} type={group.type} dayIndex={group.dayIndex} />
           {group.expenses.map((expense) => (
             <ExpenseItem key={`${expense.expenseId}-${expense.expenseCurrency}`} expense={expense} />

--- a/snapsplit/src/features/trip/[tripId]/_components/TotalExpenseBottomSheet.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/TotalExpenseBottomSheet.tsx
@@ -9,16 +9,18 @@ const TotalExpenseBottomSheet = ({ tripTotalExpense = 0 }: TotalExpenseBottomShe
   // 지출 금 "원" 으로 표기할지 상의
 
   return (
-    <div className="relative flex flex-col items-center bg-neutral-500 pt-[22px] pb-[18px]">
-      {/* 위쪽 화살표 */}
-      <Image
-        alt="↑"
-        src={topArrow}
-        className="absolute top-[2px]" // 겹치게 위로 끌어올림
-      />
+    <div>
+      <div className="relative flex flex-col items-center bg-neutral-500 pt-[22px] pb-[18px]">
+        {/* 위쪽 화살표 */}
+        <Image
+          alt="↑"
+          src={topArrow}
+          className="absolute top-[2px]" // 겹치게 위로 끌어올림
+        />
 
-      {/* 텍스트 */}
-      <div className="text-grey-50 text-title-1 z-10">총 {tripTotalExpense.toLocaleString()}원 지출</div>
+        {/* 텍스트 */}
+        <div className="text-grey-50 text-title-1 z-10">총 {tripTotalExpense.toLocaleString()}원 지출</div>
+      </div>
     </div>
   );
 };

--- a/snapsplit/src/features/trip/[tripId]/_components/TotalExpenseBottomSheet.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/TotalExpenseBottomSheet.tsx
@@ -9,18 +9,16 @@ const TotalExpenseBottomSheet = ({ tripTotalExpense = 0 }: TotalExpenseBottomShe
   // 지출 금 "원" 으로 표기할지 상의
 
   return (
-    <div>
-      <div className="relative flex flex-col items-center bg-neutral-500 pt-[22px] pb-[18px]">
-        {/* 위쪽 화살표 */}
-        <Image
-          alt="↑"
-          src={topArrow}
-          className="absolute top-[2px]" // 겹치게 위로 끌어올림
-        />
+    <div className="relative flex flex-col items-center bg-neutral-500 pt-[22px] pb-[18px]">
+      {/* 위쪽 화살표 */}
+      <Image
+        alt="총 지출 모달 열기"
+        src={topArrow}
+        className="absolute top-[2px]" // 겹치게 위로 끌어올림
+      />
 
-        {/* 텍스트 */}
-        <div className="text-grey-50 text-title-1 z-10">총 {tripTotalExpense.toLocaleString()}원 지출</div>
-      </div>
+      {/* 텍스트 */}
+      <div className="text-grey-50 text-title-1 z-10">총 {tripTotalExpense.toLocaleString()}원 지출</div>
     </div>
   );
 };

--- a/snapsplit/src/features/trip/[tripId]/_components/TripDateBar.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/TripDateBar.tsx
@@ -17,16 +17,19 @@ const TripDateBar = ({ startDate, endDate }: TripDateFilterBarProps) => {
     if (key === selectedKey) return; // 이미 선택된 날짜는 무시
     setSelectedKey(key);
 
-    // '전체'가 선택된 경우, 페이지 상단으로 스크롤 이동
-    if (key === '전체') {
-      window.scrollTo({ top: 0, behavior: 'smooth' });
-      return;
-    }
+    // '전체'의 기능이 불확실해서 일단 주석 처리
+    // // '전체'가 선택된 경우, 페이지 상단으로 스크롤 이동
+    // if (key === '전체') {
+    //   window.scrollTo({ top: 0, behavior: 'smooth' });
+    //   return;
+    // }
 
     // 선택된 날짜로 스크롤 이동
     const el = document.getElementById(`day-${key}`);
     if (el) {
       el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } else {
+      console.warn(`[TripDateBar] 스크롤 대상 day-${key} 을(를) 찾지 못했습니다.`);
     }
   };
 

--- a/snapsplit/src/features/trip/[tripId]/_components/TripDateBar.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/TripDateBar.tsx
@@ -8,11 +8,29 @@ import { getKoreanDay } from '@/shared/utils/getKoreanDay';
 import { useState } from 'react';
 import { useDragScroll } from '@/shared/utils/useDragScroll';
 
-const TripDateFilterBar = ({ startDate, endDate }: TripDateFilterBarProps) => {
+const TripDateBar = ({ startDate, endDate }: TripDateFilterBarProps) => {
   const dateList = getDateRangeArray(startDate, endDate);
   const [selectedKey, setSelectedKey] = useState<string>('전체');
 
-  const handleClick = (key: string) => setSelectedKey(key);
+  const handleClick = (key: string) => {
+    // 선택된 날짜로 상태 업데이트
+    if (key === selectedKey) return; // 이미 선택된 날짜는 무시
+    setSelectedKey(key);
+
+    // '전체'가 선택된 경우, 페이지 상단으로 스크롤 이동
+    if (key === '전체') {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+
+    // 선택된 날짜로 스크롤 이동
+    const el = document.getElementById(`day-${key}`);
+    if (el) {
+      el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+  };
+
+  // 선택된 날짜가 현재 선택된 키와 같은지 확인
   const isSelected = (key: string) => selectedKey === key;
 
   // 마우스 드래그
@@ -68,4 +86,4 @@ const TripDateFilterBar = ({ startDate, endDate }: TripDateFilterBarProps) => {
   );
 };
 
-export default TripDateFilterBar;
+export default TripDateBar;

--- a/snapsplit/src/features/trip/[tripId]/_components/TripDateBar.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/TripDateBar.tsx
@@ -17,13 +17,6 @@ const TripDateBar = ({ startDate, endDate }: TripDateFilterBarProps) => {
     if (key === selectedKey) return; // 이미 선택된 날짜는 무시
     setSelectedKey(key);
 
-    // '전체'의 기능이 불확실해서 일단 주석 처리
-    // // '전체'가 선택된 경우, 페이지 상단으로 스크롤 이동
-    // if (key === '전체') {
-    //   window.scrollTo({ top: 0, behavior: 'smooth' });
-    //   return;
-    // }
-
     // 선택된 날짜로 스크롤 이동
     const el = document.getElementById(`day-${key}`);
     if (el) {

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
@@ -10,7 +10,7 @@ const BottomSheetTrigger = ({ total }: { total: number }) => {
   return (
     <>
       <div
-        className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] bg-neutral-500 text-white py-4 text-center z-50"
+        className="mb-10 fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] bg-neutral-500 text-white py-4 text-center z-50"
         onClick={() => setOpen(true)}
       >
         총 {total.toLocaleString()}원 지출 ↑

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
@@ -16,7 +16,7 @@ const BottomSheetTrigger = ({ total }: { total: number }) => {
         onClick={() => setOpen(true)}
       >
         <Image
-          alt="↑"
+          alt="지출 상세 모달 열기"
           src={topArrow}
           className="absolute top-[2px]" // 겹치게 위로 끌어올림
         />

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useState } from 'react';
+import FullExpenseModal from './FullExpenseModal';
+import { AnimatePresence } from 'framer-motion';
+
+const BottomSheetTrigger = ({ total }: { total: number }) => {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <>
+      <div
+        className="fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] bg-neutral-500 text-white py-4 text-center z-50"
+        onClick={() => setOpen(true)}
+      >
+        총 {total.toLocaleString()}원 지출 ↑
+      </div>
+
+      <AnimatePresence>{open && <FullExpenseModal onClose={() => setOpen(false)} />}</AnimatePresence>
+    </>
+  );
+};
+
+export default BottomSheetTrigger;

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
@@ -12,7 +12,7 @@ const BottomSheetTrigger = ({ total }: { total: number }) => {
   return (
     <>
       <div
-        className="mb-10 fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] bg-neutral-500 pt-[22px] pb-[18px] flex flex-col items-center z-50"
+        className="lg:max-w-[360px] mx-auto mb-10 fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] bg-neutral-500 pt-[22px] pb-[18px] flex flex-col items-center z-50"
         onClick={() => setOpen(true)}
       >
         <Image

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/BottomSheetTrigger.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import FullExpenseModal from './FullExpenseModal';
 import { AnimatePresence } from 'framer-motion';
+import Image from 'next/image';
+import topArrow from '@public/svg/topArrow.svg';
 
 const BottomSheetTrigger = ({ total }: { total: number }) => {
   const [open, setOpen] = useState(false);
@@ -10,10 +12,15 @@ const BottomSheetTrigger = ({ total }: { total: number }) => {
   return (
     <>
       <div
-        className="mb-10 fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] bg-neutral-500 text-white py-4 text-center z-50"
+        className="mb-10 fixed bottom-0 left-1/2 -translate-x-1/2 w-full max-w-[415px] min-w-[360px] bg-neutral-500 pt-[22px] pb-[18px] flex flex-col items-center z-50"
         onClick={() => setOpen(true)}
       >
-        총 {total.toLocaleString()}원 지출 ↑
+        <Image
+          alt="↑"
+          src={topArrow}
+          className="absolute top-[2px]" // 겹치게 위로 끌어올림
+        />
+        <div className="text-grey-50 text-title-1 z-10">총 {total.toLocaleString()}원 지출</div>
       </div>
 
       <AnimatePresence>{open && <FullExpenseModal onClose={() => setOpen(false)} />}</AnimatePresence>

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/FullExpenseModal.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/FullExpenseModal.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { motion } from 'framer-motion';
+
+type Props = {
+  onClose: () => void;
+};
+
+const FullExpenseModal = ({ onClose }: Props) => {
+  return (
+    <motion.div
+      initial={{ y: '100%' }} // 아래에서 시작
+      animate={{ y: 0 }} // 올라오기
+      exit={{ y: '100%' }} // 아래로 사라짐
+      transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+      className="fixed inset-0 z-[999] bg-white flex flex-col"
+    >
+      <button onClick={onClose} className="p-4 text-right text-grey-700">
+        닫기 ✕
+      </button>
+      <div className="flex-1 overflow-y-auto px-4">
+        <h2 className="text-xl font-bold mb-4">전체 지출 내역</h2>
+        {/* 내용 들어갈 부분 */}
+      </div>
+    </motion.div>
+  );
+};
+
+export default FullExpenseModal;

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/FullExpenseModal.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/FullExpenseModal.tsx
@@ -12,6 +12,7 @@ const FullExpenseModal = ({ onClose }: Props) => {
       initial={{ y: '100%' }} // 아래에서 시작
       animate={{ y: 0 }} // 올라오기
       exit={{ y: '100%' }} // 아래로 사라짐
+      layout
       transition={{ type: 'spring', stiffness: 300, damping: 30 }}
       className="fixed inset-0 z-[999] bg-white flex flex-col"
     >

--- a/snapsplit/src/shared/utils/groupExpenses.ts
+++ b/snapsplit/src/shared/utils/groupExpenses.ts
@@ -5,6 +5,7 @@ import { getKoreanDay } from './getKoreanDay';
 
 dayjs.extend(isSameOrBefore);
 type GroupedExpenses = {
+  id?: string; // 스크롤 이동용 ID
   type: 'PRE_TRIP' | 'IN_TRIP';
   dayIndex?: number;
   label: string; // ex. '4.7(월)', '여행준비'
@@ -37,13 +38,13 @@ export function groupExpensesByDate(
 
   while (current.isSameOrBefore(end)) {
     const dateKey = current.format('YYYY-MM-DD');
-    const label = `${current.format('M.D')}(${getKoreanDay(current)})`;
-
+    const label = `${current.format('M.D')}/${getKoreanDay(current)}`;
     const dayExpenses = expenses.filter((e) =>
       dayjs(e.expenseDate).isSame(dateKey, 'day')
     );
 
     result.push({
+      id: dateKey,
       type: 'IN_TRIP',
       dayIndex,
       label,


### PR DESCRIPTION
## 📌 개요
- 총 지출 상세 내역 바텀 모달 시트 인터렉션 개발

## ✨ 변경 사항
- [x] 총 지출 상세 내역 바텀 모달 시트 인터렉션 개발
- 참고 사항 정독 해주세요

## 🎥 작업 스크린샷
<img width="311" alt="image" src="https://github.com/user-attachments/assets/7fe5c537-f694-45bb-9843-532c1ca39a64" />

## 🚧 남은 작업
- [ ] 지출 상세 모달 UI 개발

## 📝 참고 사항
- 하단 NavBar 가리지 않기 위해 margin 적용
- 2가지 모델로 개발
  - modal 폴더
    - modal로 만들어서, 하단 버튼 클릭 시 전체화면 모달 뜨도록
  - `TotalExpenseBottomModal`
    - 바텀 시트로 만들어서, 상단으로 올릴 시 위치 고정
    - 여러모로 애매해서 일단 보류

## 📎 관련 이슈 
- Closes #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 새로운 하단 시트 트리거(총 지출 금액 클릭 시 전체 지출 내역 모달 표시) 및 전체 지출 내역 모달이 추가되었습니다.
  - 드래그 가능한 하단 시트 UI 컴포넌트가 도입되었습니다.
  - 루트 레이아웃에 모달 전용 DOM 노드가 추가되었습니다.

- **개선 및 변경**
  - 날짜 바 필터가 개선되어 선택된 날짜로 스크롤 이동이 가능해졌습니다.
  - 일부 날짜 포맷 및 라벨 형식이 일관성 있게 변경되었습니다.
  - 스크롤 타겟 및 각 날짜별 구간에 고유 id가 부여되어 탐색이 편리해졌습니다.
  - 총 지출 하단 시트 표시 방식이 트리거 기반으로 변경되었습니다.

- **버그 수정**
  - 날짜 선택 시 이미 선택된 날짜는 중복 처리되지 않도록 개선되었습니다.

- **기타**
  - 구조 및 스타일이 일부 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->