### PR TITLE
[Feat] 바텀시트 UI

### DIFF
--- a/snapsplit/src/features/trip/[tripId]/_components/modal/FullExpenseModal.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/FullExpenseModal.tsx
@@ -1,29 +1,43 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import Image from 'next/image';
+import ModalMotionWrapper from './ModalMotionWrapper';
 
 type Props = {
   onClose: () => void;
 };
 
+// TODO: data fetch
+const expenses = {
+  "점심": 10000,
+  "기차 예매": 20000,
+  "간식": 30000,
+  "쇼핑": 40000,
+}
+
+const total = Object.values(expenses).reduce((acc, cur) => acc + cur, 0);
+
 const FullExpenseModal = ({ onClose }: Props) => {
   return (
-    <motion.div
-      initial={{ y: '100%' }} // 아래에서 시작
-      animate={{ y: 0 }} // 올라오기
-      exit={{ y: '100%' }} // 아래로 사라짐
-      layout
-      transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-      className="w-full h-full bg-white flex flex-col"
-    >
-      <button onClick={onClose} className="p-4 text-right text-grey-700">
-        닫기 ✕
-      </button>
-      <div className="flex-1 overflow-y-auto px-4">
-        <h2 className="text-xl font-bold mb-4">전체 지출 내역</h2>
-        {/* 내용 들어갈 부분 */}
+    <ModalMotionWrapper>
+      <div className="px-5 py-3 h-12">
+        <button onClick={onClose}>
+          <Image src="/svg/exit.svg" alt="닫기" width={24} height={24} />
+        </button>
       </div>
-    </motion.div>
+      <div className="flex justify-center pt-1 pb-4 border-b-1 border-grey-250">
+        <div className="text-title-1">총 {total.toLocaleString()}원 지출</div>
+      </div>
+
+      <div className="flex flex-col">
+        {Object.entries(expenses).map(([category, amount]) => (
+          <div key={category} className="flex justify-between px-5 py-4">
+            <div className="text-label-2 text-grey-650">{category}</div>
+            <div className="text-label-1 text-grey-850">{amount.toLocaleString()}원</div>
+          </div>
+        ))}
+      </div>
+    </ModalMotionWrapper>
   );
 };
 

--- a/snapsplit/src/features/trip/[tripId]/_components/modal/ModalMotionWrapper.tsx
+++ b/snapsplit/src/features/trip/[tripId]/_components/modal/ModalMotionWrapper.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { motion } from 'framer-motion';
+import { ReactNode } from 'react';
+
+type ModalMotionWrapperProps = {
+  children: ReactNode;
+};
+
+const ModalMotionWrapper = ({ children }: ModalMotionWrapperProps) => {
+  return (
+    <motion.div
+      initial={{ y: '100%' }}
+      animate={{ y: 0 }}
+      exit={{ y: '100%' }}
+      transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+      className="w-full h-full bg-white flex flex-col"
+    >
+      {children}
+    </motion.div>
+  );
+};
+
+export default ModalMotionWrapper;


### PR DESCRIPTION
## 📌 개요
- 지출상세바텀시트 UI

## ✨ 변경 사항
- [x] UI 작업

## 🎥 작업 스크린샷
![image](https://github.com/user-attachments/assets/29f62703-6274-4f59-be9b-4be870e99a4a)

## 📎 관련 이슈 
- Closes #9 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 모달 애니메이션을 위한 커스텀 래퍼가 추가되어, 모달 열기/닫기 시 부드러운 전환 효과가 적용되었습니다.
  * 전체 지출 금액과 카테고리별 지출 내역이 모달 상단에 동적으로 표시됩니다.
  * 닫기 버튼이 아이콘 형태로 변경되어 시각적으로 개선되었습니다.

* **스타일**
  * 모달 레이아웃과 스타일이 개선되어 가독성과 사용성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->