### PR TITLE
[Refactor] bottom sheet 공용 컴포넌트

### DIFF
--- a/snapsplit/src/shared/components/Calendar.tsx
+++ b/snapsplit/src/shared/components/Calendar.tsx
@@ -48,7 +48,7 @@ export default function Calendar({ selectedDate, setSelectedDate }: CalendarProp
   };
 
   return (
-    <div className="flex flex-col items-center justify-center gap-2 py-4 bg-white rounded-2xl w-full">
+    <div className="flex flex-col items-center w-full px-1.5 py-4 gap-2">
       <div className="flex items-center justify-between w-70">
         <h2 className="text-label-1">{format(currentMonth, 'yyyy년 M월')}</h2>
         <div className="flex items-center gap-3">

--- a/snapsplit/src/shared/components/bottom-sheet/BottomSheet.tsx
+++ b/snapsplit/src/shared/components/bottom-sheet/BottomSheet.tsx
@@ -1,6 +1,7 @@
 import OverlayModal from '../modal/OverlayModal';
 import Image from 'next/image';
 import grabber from '@public/svg/grabber.svg';
+import { motion, useMotionValue, useDragControls, animate } from 'framer-motion';
 
 type BottomSheetProps = {
   isOpen: boolean;
@@ -9,12 +10,52 @@ type BottomSheetProps = {
 };
 
 const BottomSheet = ({ isOpen, onClose, children }: BottomSheetProps) => {
+  const y = useMotionValue(0);
+  const controls = useDragControls();
+
+  const animateAndClose = async () => {
+    await animate(y, 500, { type: 'tween', duration: 0.2, ease: 'easeIn' });
+    onClose?.();
+  };
+
   return (
     <OverlayModal isOpen={isOpen} onClose={onClose} position="bottom">
-      <div className="flex flex-col items-center w-full pt-3 px-5 pb-8 gap-3 bg-white rounded-t-xl">
-        <Image alt="grabber" src={grabber} width={grabber.width} height={grabber.height} />
-        {children}
-      </div>
+      <motion.div
+        style={{ y }}
+        initial={{ y: '100%' }}
+        animate={{ y: 0 }}
+        exit={{ y: '100%' }}
+        transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+        className="w-full"
+        drag="y"
+        dragListener={false}
+        dragControls={controls}
+        onDrag={(e, info) => {
+          if (info.offset.y > 0) {
+            y.set(info.offset.y);
+          } else {
+            y.set(0);
+          }
+        }}
+        onDragEnd={() => {
+          const currentY = y.get();
+          if (currentY > 20) {
+            animateAndClose();
+          } else {
+            animate(y, 0, { type: 'spring', stiffness: 300, damping: 30 });
+          }
+        }}
+      >
+        <div className="flex flex-col items-center w-full pt-3 px-5 pb-8 gap-3 bg-white rounded-t-[20px]">
+          <motion.div
+            className="cursor-grab active:cursor-grabbing touch-none"
+            onPointerDown={(e) => controls.start(e)}
+          >
+            <Image alt="grabber" src={grabber} width={grabber.width} height={grabber.height} />
+          </motion.div>
+          {children}
+        </div>
+      </motion.div>
     </OverlayModal>
   );
 };

--- a/snapsplit/src/shared/components/bottom-sheet/BottomSheet.tsx
+++ b/snapsplit/src/shared/components/bottom-sheet/BottomSheet.tsx
@@ -14,8 +14,8 @@ const BottomSheet = ({ isOpen, onClose, children }: BottomSheetProps) => {
   const controls = useDragControls();
 
   const animateAndClose = async () => {
-    await animate(y, 500, { type: 'tween', duration: 0.2, ease: 'easeIn' });
-    onClose?.();
+    await animate(y, window.innerHeight, { type: 'tween', duration: 0.2, ease: 'easeIn' });
+    onClose();
   };
 
   return (


### PR DESCRIPTION
## ✨ 개요  
- 바텀시트 공용 컴포넌트

## ✅ 세부 내용
- 공용 컴포넌트 개발 및 적용
- grabber 에도 motion.div 를 줘서 drag 이벤트가 도중에 끊기는 문제 해결

## 📎 실행 화면
<img width="375" height="819" alt="image" src="https://github.com/user-attachments/assets/146baedf-fbfd-4c16-9cdc-af94a809f4e8" />
<img width="375" height="822" alt="image" src="https://github.com/user-attachments/assets/46417a96-d792-4666-99c3-b28be8d7a198" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * BottomSheet 컴포넌트에 드래그하여 닫기 기능이 추가되었습니다. 이제 사용자는 하단 시트를 드래그하여 닫을 수 있습니다.

* **스타일**
  * Calendar 컴포넌트의 레이아웃 및 스타일이 일부 변경되었습니다.
  * BottomSheet의 모서리 둥글기 및 시트 스타일이 소폭 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->