### PR TITLE
[Fix] 선택 날짜 하이라이트 반응형 적용

### DIFF
--- a/snapsplit/src/shared/components/Calendar.tsx
+++ b/snapsplit/src/shared/components/Calendar.tsx
@@ -95,9 +95,9 @@ export default function Calendar({
                 <button
                   key={`${date.toISOString()}-${index}`}
                   onClick={() => onSelectDate(date)}
-                  className="relative flex w-11 h-11 items-center justify-center"
+                  className="relative flex w-full h-11 items-center justify-center"
                 >
-                  <div className={`flex w-10 h-10 items-center justify-center ${
+                  <div className={`flex w-full h-10 items-center justify-center ${
                     isInRange ? 'bg-pale_green w-11' : 'bg-transparent w-10 rounded-full'
                   }`}>
                     <span


### PR DESCRIPTION
## ✨ 개요  
- 여행 생성 캘린더 UI 반응형 대응

## ✅ 세부 내용
- 선택 날짜 하이라이트가 디스플레이 width 에 따라 끊겨서 적용 됨

## 관련 이슈
- Closes #64 