### PR TITLE
[Fix] 로그인 api 중복 호출 문제

### DIFF
--- a/snapsplit/src/app/(no-gnb)/oauth/callback/kakao/page.tsx
+++ b/snapsplit/src/app/(no-gnb)/oauth/callback/kakao/page.tsx
@@ -5,7 +5,6 @@ import publicInstance from '@/api/instance/publicInstance';
 import { useRouter } from 'next/navigation';
 
 export default function KaKaoRedirect() {
-  console.log('[KakaoRedirect]: 마운트');
   const hasRequested = useRef(false);
   const router = useRouter();
   useEffect(() => {
@@ -16,7 +15,7 @@ export default function KaKaoRedirect() {
 
     if (!code) {
       alert('인증 코드가 없습니다.');
-      router.push('/');
+      router.replace('/');
       return;
     }
 
@@ -24,11 +23,11 @@ export default function KaKaoRedirect() {
       try {
         const res = await publicInstance.post(`/auth/kakao/login?code=${code}`);
         if (res.status === 200) {
-          router.push('/home');
+          router.replace('/home');
         }
       } catch (error) {
         console.error('카카오 로그인 실패 : ', error);
-        router.push('/');
+        router.replace('/');
       }
     };
     kakaoLogin();

--- a/snapsplit/src/app/layout.tsx
+++ b/snapsplit/src/app/layout.tsx
@@ -28,10 +28,10 @@ export default function RootLayout({
         content="width=device-width,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,user-scalable=no,viewport-fit=cover"
       />
       <body className="h-[100dvh] min-w-[360px] max-w-[415px] lg:max-w-[360px] mx-auto bg-white text-grey-1000 scroll-smooth">
-        <QueryProvider showDevtools={process.env.NODE_ENV === 'development'}>
-          <div id="modal-root" />
-          {children}
-        </QueryProvider>
+          <QueryProvider showDevtools={process.env.NODE_ENV === 'development'}>
+            <div id="modal-root" />
+            {children}
+          </QueryProvider>
       </body>
     </html>
   );

--- a/snapsplit/src/lib/providers/QueryProvider.tsx
+++ b/snapsplit/src/lib/providers/QueryProvider.tsx
@@ -2,7 +2,7 @@
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 interface QueryProviderProps {
   children: React.ReactNode;
@@ -15,23 +15,14 @@ export default function QueryProvider({ children, showDevtools = false }: QueryP
       new QueryClient({
         defaultOptions: {
           queries: {
-            staleTime: 1000 * 60 * 5, // 5분
+            staleTime: 1000 * 60 * 5,    // 5분
             retry: 1,
+            refetchOnMount: false,       // 마운트 시 재요청 방지
+            refetchOnWindowFocus: false, // 포커스 복귀 시 재요청 방지
           },
         },
       })
   );
-
-  const [isMounted, setIsMounted] = useState(false);
-
-  useEffect(() => {
-    setIsMounted(true);
-  }, []);
-
-  // SSR 중에는 기본 렌더링, 클라이언트에서 마운트 후 QueryProvider 적용
-  if (!isMounted) {
-    return <>{children}</>;
-  }
 
   return (
     <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
## 개요
- 로그인 api 중복 호출 문제 발생

## 세부 내용
- RootLayout 에 배치된 QueryProvider 가 내부적으로 children 을 두 번 렌더하도록 짜여있었음
- 해당 코드 제거 후 정상 작동 확인

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 카카오 로그인 콜백에서 중복 로그인 요청을 방지하고, 로그인 후 히스토리 스택에 새로운 기록이 추가되지 않도록 개선되었습니다.

* **스타일**
  * 레이아웃의 JSX 들여쓰기가 일관성 있게 정리되었습니다.

* **리팩터**
  * QueryProvider가 항상 자식 컴포넌트를 즉시 렌더링하도록 변경되었으며, 자동 데이터 재요청(마운트 및 창 포커스 시)이 비활성화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->