### PR TITLE
[Fix] GNB 경로 감지 문제

### DIFF
--- a/snapsplit/src/shared/components/GNB.tsx
+++ b/snapsplit/src/shared/components/GNB.tsx
@@ -33,7 +33,7 @@ export default function GNB() {
     <nav className="fixed bottom-0 h-15 display-w-full border-t border-grey-250 bg-white z-navbar">
       <div className="flex w-full items-center py-[9px]">
         {tabs.map((tab) => {
-          const isActive = pathname === tab.path;
+          const isActive = isActiveTab(pathname, tab.path);
           return (
             <button
               key={tab.label}
@@ -55,3 +55,8 @@ export default function GNB() {
     </nav>
   );
 }
+
+const isActiveTab = (pathname: string, tabPath: string) => {
+  // pathname이 tabPath로 시작하는지 확인
+  return pathname.startsWith(tabPath);
+};

--- a/snapsplit/src/shared/components/GNB.tsx
+++ b/snapsplit/src/shared/components/GNB.tsx
@@ -58,5 +58,5 @@ export default function GNB() {
 
 const isActiveTab = (pathname: string, tabPath: string) => {
   // pathname이 tabPath로 시작하는지 확인
-  return pathname.startsWith(tabPath);
+  return pathname === tabPath || pathname.startsWith(`${tabPath}/`);
 };


### PR DESCRIPTION
## 개요
- GNB 경로 감지 문제

## 세부 내용
- split/[settlementId] 페이지에서 SPLIT 탭 하이라이트가 적용되지 않음

## 해결 방안
- 활성 탭 여부 계산 방식으로 하위 경로를 포함하도록 변경

## 결과 화면
<img width="357" height="778" alt="image" src="https://github.com/user-attachments/assets/db8a012b-abf8-44b7-9bc9-3322a4946dd3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 하위 경로에서도 탭이 활성화되도록 탭 활성화 로직이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->