### PR TITLE
[Feat] 기본홈 api 연동, 여행 없을 시 랜더링 로직 추가

### DIFF
--- a/snapsplit/src/features/home/HomePage.tsx
+++ b/snapsplit/src/features/home/HomePage.tsx
@@ -1,16 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import HomeHeader from './_components/HomeHeader';
 import CreateTripSection from './_components/CreateTripSection';
 import PastTripImgCardList from './_components/PastTripImgCardList';
 import AllPastTripList from './_components/AllPastTripList';
-import mock from '@public/mocks/home-mock.json';
+import { getHomeData } from './api/home-api';
+import { GetHomeResponseDto } from './type/home-type';
 
 export default function HomePage() {
+  const [homeData, setHomeData] = useState<GetHomeResponseDto | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const hasPastTrip = homeData?.pastTrips && homeData.pastTrips.length > 0;
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const data = await getHomeData();
+        setHomeData(data);
+        console.log('홈 데이터:', data);
+      } catch (e) {
+        console.log('홈 데이터 로딩 실패:', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchData();
+  }, []);
+
+  if (loading) return <div>로딩중...</div>;
+  if (!homeData) return <div>데이터를 불러오지 못했습니다.</div>;
+
   return (
-    <div className="bg-grey-50 min-h-[100dvh] pb-6">
+    <div className="flex flex-col bg-grey-50 min-h-[100dvh] pb-6">
       <HomeHeader />
-      <CreateTripSection upcomingTrips={mock.data.upcomingTrips} ongoingTrips={mock.data.ongoingTrips} />
-      <PastTripImgCardList />
-      <AllPastTripList pastTrips={mock.data.pastTrips} />
+      <CreateTripSection upcomingTrips={homeData.upcomingTrips} ongoingTrips={homeData.ongoingTrips} />
+      {hasPastTrip ? (
+        <>
+          <PastTripImgCardList />
+          <AllPastTripList pastTrips={homeData.pastTrips} />
+        </>
+      ) : (
+        <div className="flex flex-1 text-grey-450 text-label-1">
+          <span className="flex flex-col w-full items-center justify-center text-center">
+            지금 바로 여행을 등록하고
+            <br />
+            여행홈을 둘러보세요!
+          </span>
+        </div>
+      )}
     </div>
   );
 }

--- a/snapsplit/src/features/home/_components/AllPastTripList.tsx
+++ b/snapsplit/src/features/home/_components/AllPastTripList.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { PastTripListProps, AllPastTripListProps } from '../types';
+import { PastTripListProps, AllPastTripListProps } from '../type/home-type';
 import { useISOtoFormattedDate } from '@/shared/utils/useISOtoFormattedDate';
 
 const PastTripItem = ({ tripId, tripName, startDate, endDate }: PastTripListProps) => {
@@ -21,6 +21,8 @@ const PastTripItem = ({ tripId, tripName, startDate, endDate }: PastTripListProp
 };
 
 const AllPastTripList = ({ pastTrips }: AllPastTripListProps) => {
+  const hasPastTrip = pastTrips && pastTrips.length > 0;
+
   return (
     <div className="px-5">
       <section className="flex flex-col bg-white rounded-[20px] py-4 px-5">
@@ -31,16 +33,17 @@ const AllPastTripList = ({ pastTrips }: AllPastTripListProps) => {
           </Link>
         </div>
 
-        {pastTrips.map((trip) => (
-          <PastTripItem
-            key={trip.tripId}
-            tripId={trip.tripId}
-            tripName={trip.tripName}
-            startDate={trip.startDate}
-            endDate={trip.endDate}
-            countryNames={trip.countryNames}
-          />
-        ))}
+        {hasPastTrip &&
+          pastTrips.map((trip) => (
+            <PastTripItem
+              key={trip.tripId}
+              tripId={trip.tripId}
+              tripName={trip.tripName}
+              startDate={trip.startDate}
+              endDate={trip.endDate}
+              countryNames={trip.countryNames}
+            />
+          ))}
       </section>
     </div>
   );

--- a/snapsplit/src/features/home/_components/CreateTripSection.tsx
+++ b/snapsplit/src/features/home/_components/CreateTripSection.tsx
@@ -5,26 +5,41 @@ import CurrentTripList from './CurrentTripList';
 import OverlayModal from '@/shared/components/modal/OverlayModal';
 import JoinTripByCodeModal from './modal/JoinTripByCodeModal';
 import { useState } from 'react';
-import { CreateTripSectionProps } from '../types';
+import { CreateTripSectionProps } from '../type/home-type';
+import { getDaysUntilTrip } from '@/shared/utils/DatetoDay/getDaysUntilTrip';
 
 const CreateTripSection = ({ upcomingTrips, ongoingTrips }: CreateTripSectionProps) => {
   const [isJoinModalOpen, setIsJoinModalOpen] = useState(false);
 
-  const openJoinModal = () => {
-    setIsJoinModalOpen(true);
-  };
+  const openJoinModal = () => setIsJoinModalOpen(true);
+  const closeJoinModal = () => setIsJoinModalOpen(false);
 
-  const closeJoinModal = () => {
-    setIsJoinModalOpen(false);
-  };
+  // 둘 중 하나라도 길이가 0 이상이면 렌더링
+  const hasOngoing = ongoingTrips && ongoingTrips.length > 0;
+  const hasUpcoming = upcomingTrips && upcomingTrips.length > 0;
+  const hasCurrentTrips = hasOngoing || hasUpcoming;
 
   return (
     <section className="flex flex-col w-full pb-4 pt-2 rounded-b-3xl gap-5 bg-white">
       <span className="text-head-1 flex-auto px-5">
-        스냅스플릿과 함께
-        <br /> 재밌는 여행을 떠나볼까요?
+        {hasOngoing ? (
+          <>
+            지금 여행 중이시군요!
+            <br /> 오늘도 즐거운 여행 되세요
+          </>
+        ) : hasUpcoming ? (
+          <>
+            {upcomingTrips[0].tripName}
+            <br /> 여행이 {getDaysUntilTrip(upcomingTrips[0].startDate)}일 남았어요!
+          </>
+        ) : (
+          <>
+            스냅스플릿과 함께
+            <br /> 재밌는 여행을 떠나볼까요?
+          </>
+        )}
       </span>
-      <CurrentTripList upcomingTrips={upcomingTrips} ongoingTrips={ongoingTrips} />
+      {hasCurrentTrips && <CurrentTripList upcomingTrips={upcomingTrips} ongoingTrips={ongoingTrips} />}
       <div className="flex flex-col w-full gap-4 px-5">
         <Link href="/trip/createTrip" className="flex bg-primary py-[14px] px-5 justify-center text-grey-50 rounded-xl">
           여행 등록하기

--- a/snapsplit/src/features/home/_components/CurrentTripList.tsx
+++ b/snapsplit/src/features/home/_components/CurrentTripList.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useDragScroll } from '@/shared/utils/useDragScroll';
-import { CurrentTripListProps } from '../types';
+import { CurrentTripListProps } from '../type/home-type';
 import { getDaysUntilTrip } from '@/shared/utils/DatetoDay/getDaysUntilTrip';
 import Link from 'next/link';
 
@@ -16,7 +16,6 @@ type CurrentTripItemProps = {
 const CurrentTripItem = ({ tripId, tripName, startDate, endDate, countryNames }: CurrentTripItemProps) => {
   const daysLeft = getDaysUntilTrip(startDate);
 
-  // D-day 라벨링
   let dLabel: string;
   if (daysLeft > 0) {
     dLabel = `D-${daysLeft}`;
@@ -58,6 +57,9 @@ const CurrentTripItem = ({ tripId, tripName, startDate, endDate, countryNames }:
 const CurrentTripList = ({ upcomingTrips, ongoingTrips }: CurrentTripListProps) => {
   const { scrollRef, onMouseDown, onMouseMove, onMouseUp } = useDragScroll('x');
 
+  const hasOngoing = ongoingTrips && ongoingTrips.length > 0;
+  const hasUpcoming = upcomingTrips && upcomingTrips.length > 0;
+
   return (
     <div
       ref={scrollRef}
@@ -67,26 +69,28 @@ const CurrentTripList = ({ upcomingTrips, ongoingTrips }: CurrentTripListProps) 
       onMouseLeave={onMouseUp}
       className="flex overflow-x-auto scrollbar-hide px-8"
     >
-      {ongoingTrips.map((trip) => (
-        <CurrentTripItem
-          key={trip.tripId}
-          tripId={trip.tripId}
-          tripName={trip.tripName}
-          startDate={trip.startDate}
-          endDate={trip.endDate}
-          countryNames={trip.countryNames}
-        />
-      ))}
-      {upcomingTrips.map((trip) => (
-        <CurrentTripItem
-          key={trip.tripId}
-          tripId={trip.tripId}
-          tripName={trip.tripName}
-          startDate={trip.startDate}
-          endDate={trip.endDate}
-          countryNames={trip.countryNames}
-        />
-      ))}
+      {hasOngoing &&
+        ongoingTrips.map((trip) => (
+          <CurrentTripItem
+            key={trip.tripId}
+            tripId={trip.tripId}
+            tripName={trip.tripName}
+            startDate={trip.startDate}
+            endDate={trip.endDate}
+            countryNames={trip.countryNames}
+          />
+        ))}
+      {hasUpcoming &&
+        upcomingTrips.map((trip) => (
+          <CurrentTripItem
+            key={trip.tripId}
+            tripId={trip.tripId}
+            tripName={trip.tripName}
+            startDate={trip.startDate}
+            endDate={trip.endDate}
+            countryNames={trip.countryNames}
+          />
+        ))}
     </div>
   );
 };

--- a/snapsplit/src/features/home/_components/UpcomingTripList.tsx
+++ b/snapsplit/src/features/home/_components/UpcomingTripList.tsx
@@ -1,4 +1,4 @@
-import { UpcomingTripProps } from '../types';
+import { UpcomingTripProps } from '../type/home-type';
 
 const UpcomingTrip = ({ tripName, tripCountry, tripDate, dDay }: UpcomingTripProps) => {
   return (

--- a/snapsplit/src/features/home/api/home-api.ts
+++ b/snapsplit/src/features/home/api/home-api.ts
@@ -1,0 +1,8 @@
+import privateInstance from '@/lib/api/instance/privateInstance';
+import { GetHomeResponseDto } from '../type/home-type';
+import { apiPath } from '@/shared/constants/apipath';
+
+export const getHomeData = async (): Promise<GetHomeResponseDto> => {
+  const res = await privateInstance.get<GetHomeResponseDto>(apiPath.home);
+  return res.data;
+};

--- a/snapsplit/src/features/home/past/_components/PastTripList.tsx
+++ b/snapsplit/src/features/home/past/_components/PastTripList.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import right_arrow from '@public/svg/rightArrow.svg';
 import Link from 'next/link';
-import { Trip } from '@home/types';
+import { Trip } from '@/features/home/type/home-type';
 
 type PastTripCardProps = {
   tripId: number;

--- a/snapsplit/src/features/home/type/home-type.ts
+++ b/snapsplit/src/features/home/type/home-type.ts
@@ -1,19 +1,26 @@
- export type Trip = {
+export type TripDto = {
   tripId: number;
   tripName: string;
   startDate: string;
   endDate: string;
   countryNames: string[];
- };
+  tripImage?: string;
+};
+
+export type GetHomeResponseDto = {
+  upcomingTrips: TripDto[];
+  ongoingTrips: TripDto[];
+  pastTrips: TripDto[];
+};
 
 export interface CreateTripSectionProps{
-  upcomingTrips: Trip[];
-  ongoingTrips: Trip[];
+  upcomingTrips: TripDto[];
+  ongoingTrips: TripDto[];
 }
 
 export interface CurrentTripListProps {
-  upcomingTrips: Trip[];
-  ongoingTrips: Trip[];
+  upcomingTrips: TripDto[];
+  ongoingTrips: TripDto[];
 }
 
 export type UpcomingTripProps = {
@@ -24,7 +31,7 @@ export type UpcomingTripProps = {
 };
 
 export interface PastTripImgCardListProps {
-  pastTrips: Trip[];
+  pastTrips: TripDto[];
 }
 
 export type PastTripCardProp = {
@@ -41,5 +48,5 @@ export type PastTripListProps = {
 }
 
 export interface AllPastTripListProps {
-  pastTrips: Trip[];
+  pastTrips: TripDto[];
 }

--- a/snapsplit/src/features/trip/[tripId]/budget/_components/DailyExpenseList.tsx
+++ b/snapsplit/src/features/trip/[tripId]/budget/_components/DailyExpenseList.tsx
@@ -1,4 +1,3 @@
-// DailyExpenseList.tsx
 import ExpenseDateBar from './ExpenseDateBar';
 import ExpenseItem from './ExpenseItem';
 import { DailyExpenseListProps } from '../type';

--- a/snapsplit/src/lib/api/instance/privateInstance.ts
+++ b/snapsplit/src/lib/api/instance/privateInstance.ts
@@ -11,7 +11,6 @@ privateInstance.interceptors.request.use(
         const { accessToken } = getToken(); // accessToken 가져오기
         if (accessToken) {
             config.headers["Authorization"] = `Bearer ${accessToken}`;
-            console.log("[로그인 시도] Access Token:", accessToken);
         }
         return config;
     },

--- a/snapsplit/src/lib/api/instance/privateInstance.ts
+++ b/snapsplit/src/lib/api/instance/privateInstance.ts
@@ -11,6 +11,7 @@ privateInstance.interceptors.request.use(
         const { accessToken } = getToken(); // accessToken 가져오기
         if (accessToken) {
             config.headers["Authorization"] = `Bearer ${accessToken}`;
+            console.log("[로그인 시도] Access Token:", accessToken);
         }
         return config;
     },

--- a/snapsplit/src/shared/constants/apipath.ts
+++ b/snapsplit/src/shared/constants/apipath.ts
@@ -1,0 +1,3 @@
+export const enum apiPath {
+  home = "/home",
+}


### PR DESCRIPTION
## ✨ 개요  
1. 홈/여행 관련 주요 컴포넌트의 조건부 렌더링 및 UI 개선
2. API 경로 관리 방식 개선 및 타입 명확화
3. 상태 관리 및 데이터 패칭 방식 통일

## ✅ 세부 내용
1. **홈 화면 데이터 패칭 및 상태 관리 개선**
   - `HomePage`에서 API 호출 시 로딩/에러/데이터 상태 분기 처리
   - 여행 데이터가 없을 때 안내 문구 전체 영역 차지하도록 flex 레이아웃 수정

2. **여행 리스트 컴포넌트 조건부 렌더링**
   - `CurrentTripList`, `AllPastTripList` 등에서 배열 길이가 0일 때 렌더링하지 않도록 변경
   - `CreateTripSection`에서 여행 상태에 따라 안내 문구 및 리스트 동적 렌더링

3. **API 경로 enum 타입으로 관리**
   - `apiPath.ts` 파일 생성, 주요 API 경로를 enum 타입으로 통합 관리
   - 코드 내 경로 하드코딩 제거 및 유지보수성 향상

4. **타입 명확화 및 props 전달 개선**
   - API 응답 타입을 명확하게 지정 (`HomeData`, `TripDTO` 등)
   - 각 컴포넌트에 필요한 props만 전달하도록 구조 개선

5. **기타 UI/UX 개선**
   - 안내 문구, 버튼, 모달 등 사용자 경험 향상을 위한 조건부 렌더링 및 스타일 수정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 홈 화면에서 정적 데이터 대신 실시간 데이터를 불러와 표시하도록 개선되었습니다.
  * 홈 화면에서 여행 정보가 없을 경우 등록 유도 메시지가 표시됩니다.

* **버그 수정**
  * 과거/현재/예정 여행 목록이 실제 데이터가 있을 때만 표시되도록 조건부 렌더링이 적용되었습니다.

* **스타일**
  * 홈 화면 레이아웃이 플렉스 컬럼 구조로 변경되었습니다.

* **기타**
  * API 경로 및 타입 정의가 일관성 있게 정리되었습니다.
  * 콘솔 로그로 액세스 토큰 확인 메시지가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->