### PR TITLE
[Feat] 여행홈 API 연동

### DIFF
--- a/snapsplit/middleware.ts
+++ b/snapsplit/middleware.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  // 인증이 필요한 경로 접근 시 토큰 검사
+  const protectedPaths = ['/home', '/trip'];
+  const { pathname } = request.nextUrl;
+
+  // 보호 경로에 해당하면 accessToken 쿠키 검사
+  if (protectedPaths.some((path) => pathname.startsWith(path))) {
+    const accessToken = request.cookies.get('accessToken')?.value;
+    if (!accessToken) {
+      // 로그인 페이지로 리다이렉트
+      const loginUrl = new URL('/auth', request.url);
+      return NextResponse.redirect(loginUrl);
+    }
+  }
+
+  // 인증 필요 없는 경로는 그대로 진행
+  return NextResponse.next();
+}

--- a/snapsplit/next.config.ts
+++ b/snapsplit/next.config.ts
@@ -2,7 +2,11 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   images: {
-    domains: ['i1.sndcdn.com'],
+    domains: [
+      'i1.sndcdn.com',
+      'snapsplit-assets.s3.ap-northeast-2.amazonaws.com',
+],
+    
   },
 };
 

--- a/snapsplit/src/features/home/HomePage.tsx
+++ b/snapsplit/src/features/home/HomePage.tsx
@@ -38,7 +38,7 @@ export default function HomePage() {
       <CreateTripSection upcomingTrips={homeData.upcomingTrips} ongoingTrips={homeData.ongoingTrips} />
       {hasPastTrip ? (
         <>
-          <PastTripImgCardList />
+          <PastTripImgCardList pastTrips={homeData.pastTrips} />
           <AllPastTripList pastTrips={homeData.pastTrips} />
         </>
       ) : (

--- a/snapsplit/src/features/home/_components/CurrentTripList.tsx
+++ b/snapsplit/src/features/home/_components/CurrentTripList.tsx
@@ -4,6 +4,7 @@ import { useDragScroll } from '@/shared/utils/useDragScroll';
 import { CurrentTripListProps } from '../type/home-type';
 import { getDaysUntilTrip } from '@/shared/utils/DatetoDay/getDaysUntilTrip';
 import Link from 'next/link';
+import { format } from 'date-fns';
 
 type CurrentTripItemProps = {
   tripId: number;
@@ -40,7 +41,7 @@ const CurrentTripItem = ({ tripId, tripName, startDate, endDate, countryNames }:
             className="text-caption-1 text-grey-550 w-full overflow-hidden whitespace-nowrap truncate"
             title={countryNames.join(', ')}
           >
-            {startDate} - {endDate} |{' '}
+            {format(startDate, 'yyyy. M. d')} - {format(endDate, 'yyyy. M. d')} | {''}
             {countryNames.map((country, idx) => (
               <span key={country + idx}>
                 {country}

--- a/snapsplit/src/features/home/_components/CurrentTripList.tsx
+++ b/snapsplit/src/features/home/_components/CurrentTripList.tsx
@@ -21,7 +21,7 @@ const CurrentTripItem = ({ tripId, tripName, startDate, endDate, countryNames }:
   if (daysLeft > 0) {
     dLabel = `D-${daysLeft}`;
   } else if (daysLeft < 0) {
-    dLabel = `Day ${Math.abs(daysLeft)}`;
+    dLabel = `Day ${Math.abs(daysLeft) + 1}`;
   } else {
     dLabel = 'D-day';
   }

--- a/snapsplit/src/features/home/_components/PastTripImgCardList.tsx
+++ b/snapsplit/src/features/home/_components/PastTripImgCardList.tsx
@@ -1,31 +1,37 @@
 'use client';
 
 import { useDragScroll } from '@/shared/utils/useDragScroll';
+import { PastTripImgCardListProps } from '../type/home-type';
+import { format } from 'date-fns';
+import Image from 'next/image';
 
 type PastTripCardProp = {
   tripName: string;
-  tripDate: string;
+  startDate: string;
+  tripImage: string;
 };
 
-const PastTripCard = ({ tripName, tripDate }: PastTripCardProp) => {
+const PastTripCard = ({ tripName, startDate, tripImage }: PastTripCardProp) => {
   return (
     <div className="flex-shrink-0 flex flex-col justify-center items-center bg-white rounded-2xl w-52 h-[262px] mr-4">
-      <div className="bg-grey-250 rounded-2xl w-[184px] h-[184px] mb-3"></div> {/* 여행 이미지 */}
+      <div className="bg-grey-250 rounded-2xl w-[184px] h-[184px] mb-3">
+        <Image
+          src={tripImage}
+          alt="trip image"
+          width={184}
+          height={184}
+          className="rounded-2xl object-cover w-[184px] h-[184px]"
+        />
+      </div>
+      {/* 여행 이미지 */}
       <p className="text-body-1">{tripName}</p>
-      <p className="text-body-2 text-grey-550">{tripDate}</p>
+      <p className="text-body-2 text-grey-550">{format(startDate, 'yyyy. M. d')}</p>
     </div>
   );
 };
 
-const PastTripImgCardList = () => {
+const PastTripImgCardList = ({ pastTrips }: PastTripImgCardListProps) => {
   const { scrollRef, onMouseDown, onMouseMove, onMouseUp } = useDragScroll('x');
-
-  const tripList = [
-    { tripName: '대만', tripDate: '2025.05.25' },
-    { tripName: '일본', tripDate: '2024.12.20' },
-    { tripName: '태국', tripDate: '2024.10.10' },
-    { tripName: '프랑스', tripDate: '2024.08.15' },
-  ];
 
   return (
     <div className="flex flex-col gap-3 pl-5 py-6">
@@ -38,8 +44,8 @@ const PastTripImgCardList = () => {
         onMouseLeave={onMouseUp}
         className="flex overflow-x-auto scrollbar-hide"
       >
-        {tripList.map((trip, index) => (
-          <PastTripCard key={index} tripName={trip.tripName} tripDate={trip.tripDate} />
+        {pastTrips.map((trip, tripId) => (
+          <PastTripCard key={tripId} tripName={trip.tripName} startDate={trip.startDate} tripImage={trip.tripImage} />
         ))}
       </div>
     </div>

--- a/snapsplit/src/features/home/_components/PastTripImgCardList.tsx
+++ b/snapsplit/src/features/home/_components/PastTripImgCardList.tsx
@@ -8,22 +8,22 @@ import Image from 'next/image';
 type PastTripCardProp = {
   tripName: string;
   startDate: string;
-  tripImage: string;
+  tripImage?: string;
 };
 
 const PastTripCard = ({ tripName, startDate, tripImage }: PastTripCardProp) => {
   return (
     <div className="flex-shrink-0 flex flex-col justify-center items-center bg-white rounded-2xl w-52 h-[262px] mr-4">
-      <div className="bg-grey-250 rounded-2xl w-[184px] h-[184px] mb-3">
+      {tripImage && (
         <Image
           src={tripImage}
           alt="trip image"
+          quality={60}
           width={184}
           height={184}
-          className="rounded-2xl object-cover w-[184px] h-[184px]"
+          className="rounded-2xl object-cover w-[184px] h-[184px] mb-3"
         />
-      </div>
-      {/* 여행 이미지 */}
+      )}
       <p className="text-body-1">{tripName}</p>
       <p className="text-body-2 text-grey-550">{format(startDate, 'yyyy. M. d')}</p>
     </div>

--- a/snapsplit/src/features/home/type/home-type.ts
+++ b/snapsplit/src/features/home/type/home-type.ts
@@ -19,8 +19,8 @@ export interface CreateTripSectionProps{
 }
 
 export interface CurrentTripListProps {
-  upcomingTrips: TripDto[];
-  ongoingTrips: TripDto[];
+  upcomingTrips?: TripDto[];
+  ongoingTrips?: TripDto[];
 }
 
 export type UpcomingTripProps = {

--- a/snapsplit/src/features/home/type/home-type.ts
+++ b/snapsplit/src/features/home/type/home-type.ts
@@ -14,8 +14,8 @@ export type GetHomeResponseDto = {
 };
 
 export interface CreateTripSectionProps{
-  upcomingTrips: TripDto[];
-  ongoingTrips: TripDto[];
+  upcomingTrips?: TripDto[];
+  ongoingTrips?: TripDto[];
 }
 
 export interface CurrentTripListProps {

--- a/snapsplit/src/lib/api/instance/privateInstance.ts
+++ b/snapsplit/src/lib/api/instance/privateInstance.ts
@@ -69,7 +69,7 @@ privateInstance.interceptors.response.use(
         return privateInstance(originalRequest); // 재시도 결과 반환
       } catch (error) {
         useAuthStore.getState().clearUser();
-        window.location.href = '/login';
+        window.location.href = '/auth';
         return Promise.reject(error);
       } finally {
         // 재시도 플래그 초기화


### PR DESCRIPTION
## ✨ 개요
- 인증 토큰 갱신 로직 개선
- 홈 데이터 DTO 통일
- 이미지 도메인 등록

## ✅ 세부 내용
- getHomeData API 함수에서 envelope 구조 해제 → DTO만 반환
- PastTripImgCardList에 pastTrips props 전달 및 map 오류 방어 처리
- next.config.js에 S3 도메인 등록 → 이미지 최적화 가능
- Image 컴포넌트에 sizes, quality 옵션 추가해 성능 최적화

## 📸 스크린샷/테스트 결과
<img width="732" height="1814" alt="image" src="https://github.com/user-attachments/assets/c3187bf4-090e-4b3c-9a1c-81fac6928e1d" />
<img width="1266" height="413" alt="image" src="https://github.com/user-attachments/assets/785c8f32-74d9-4b65-8e5f-d6b27232d069" />

## 🚀 추가 고려사항
- 추후 middleware.ts로 비로그인 유저 라우트 가드 추가 예정
- 쿠키 기반 인증으로 전환 시 로직 단순화 가능