### PR TITLE
[Feat] 여행 코드 조회 API 연동

### DIFF
--- a/snapsplit/src/features/trip/[tripId]/api/trip-api.ts
+++ b/snapsplit/src/features/trip/[tripId]/api/trip-api.ts
@@ -4,8 +4,12 @@ import { ApiEnvelope } from '@/lib/api/type';
 import { GetTripCodeDto } from '../types/trip-type';
 
 export const getTripCodeData = async (tripId: string): Promise<GetTripCodeDto> => {
-    const finalPath = apiPath.tripCode.replace('{tripId}', tripId);
-    
-    const res = await privateInstance.get<ApiEnvelope<GetTripCodeDto>>(finalPath);
-    return res.data.data;
+    try {
+        const finalPath = apiPath.tripCode.replace('{tripId}', tripId);
+        const res = await privateInstance.get<ApiEnvelope<GetTripCodeDto>>(finalPath);
+        return res.data.data;
+    } catch (error) {
+        console.error(`[API Error] Failed to get trip Header for tripId ${tripId}:`, error);
+        throw new Error('여행 코드를 불러오는데 실패했습니다.');
+    }
 };

--- a/snapsplit/src/features/trip/[tripId]/api/trip-api.ts
+++ b/snapsplit/src/features/trip/[tripId]/api/trip-api.ts
@@ -3,10 +3,10 @@ import { apiPath } from '@/shared/constants/apipath';
 import { ApiEnvelope } from '@/lib/api/type';
 import { GetTripCodeDto } from '../types/trip-type';
 
-export const getTripCodeData = async (tripId: string): Promise<GetTripCodeDto> => {
+export const getTripCodeData = async (tripId: string, signal?: AbortSignal): Promise<GetTripCodeDto> => {
     try {
         const finalPath = apiPath.tripCode.replace('{tripId}', tripId);
-        const res = await privateInstance.get<ApiEnvelope<GetTripCodeDto>>(finalPath);
+        const res = await privateInstance.get<ApiEnvelope<GetTripCodeDto>>(finalPath, { signal });
         return res.data.data;
     } catch (error) {
         console.error(`[API Error] Failed to get trip Header for tripId ${tripId}:`, error);

--- a/snapsplit/src/features/trip/[tripId]/api/trip-api.ts
+++ b/snapsplit/src/features/trip/[tripId]/api/trip-api.ts
@@ -1,0 +1,11 @@
+import privateInstance from '@/lib/api/instance/privateInstance';
+import { apiPath } from '@/shared/constants/apipath';
+import { ApiEnvelope } from '@/lib/api/type';
+import { GetTripCodeDto } from '../types/trip-type';
+
+export const getTripCodeData = async (tripId: string): Promise<GetTripCodeDto> => {
+    const finalPath = apiPath.tripCode.replace('{tripId}', tripId);
+    
+    const res = await privateInstance.get<ApiEnvelope<GetTripCodeDto>>(finalPath);
+    return res.data.data;
+};

--- a/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
+++ b/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
@@ -4,19 +4,18 @@ import Image from 'next/image';
 import { motion, useMotionValue, useDragControls, animate } from 'framer-motion';
 import grabber from '@public/svg/grabber.svg';
 
-const mock = 's4ks0d92';
-
 type AddMemberModalProps = {
   onClose?: () => void;
+  tripCode: string | undefined;
 };
 
-const AddMemberModal = ({ onClose }: AddMemberModalProps) => {
+const AddMemberModal = ({ onClose, tripCode }: AddMemberModalProps) => {
   const y = useMotionValue(0);
   const controls = useDragControls();
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(mock);
+      await navigator.clipboard.writeText(tripCode || '');
       alert('코드가 복사되었습니다!');
     } catch (err) {
       console.error('복사 실패:', err);
@@ -70,7 +69,7 @@ const AddMemberModal = ({ onClose }: AddMemberModalProps) => {
 
       <div className="flex pb-3 flex-col gap-1 items-center justify-center">
         <label className="text-grey-550 text-body-2">초대 코드</label>
-        <p className="text-title-1 py-2">{mock}</p>
+        <p className="text-title-1 py-2">{tripCode}</p>
       </div>
       <button
         onClick={handleCopy}

--- a/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
+++ b/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
@@ -8,7 +8,7 @@ import Button from '@/shared/components/Button'; // Button 컴포넌트 사용�
 // 1. props 타입에 isLoading, isError 추가
 type AddMemberModalProps = {
   onClose?: () => void;
-  tripCode: string | undefined;
+  tripCode?: string;
   isLoading: boolean;
   isError: boolean;
 };
@@ -20,6 +20,10 @@ const AddMemberModal = ({ onClose, tripCode, isLoading, isError }: AddMemberModa
 
   const handleCopy = async () => {
     if (!tripCode) return; // tripCode가 없을 때 복사 방지
+    if (!window.isSecureContext || !navigator.clipboard) {
+      alert('현재 환경에서 복사가 지원되지 않습니다. HTTPS 환경 또는 최신 브라우저에서 시도해 주세요.');
+      return;
+    }
     try {
       await navigator.clipboard.writeText(tripCode);
       alert('코드가 복사되었습니다!');

--- a/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
+++ b/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
@@ -15,7 +15,11 @@ const AddMemberModal = ({ onClose, tripCode }: AddMemberModalProps) => {
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(tripCode || '');
+      if (!tripCode) {
+        alert('초대 코드가 아직 준비되지 않았습니다. 새로고침 후 다시 시도해 주세요.');
+        return;
+      }
+      await navigator.clipboard.writeText(tripCode);
       alert('코드가 복사되었습니다!');
     } catch (err) {
       console.error('복사 실패:', err);

--- a/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
+++ b/snapsplit/src/features/trip/[tripId]/budget/_components/modal/addMemberModal.tsx
@@ -3,22 +3,24 @@
 import Image from 'next/image';
 import { motion, useMotionValue, useDragControls, animate } from 'framer-motion';
 import grabber from '@public/svg/grabber.svg';
+import Button from '@/shared/components/Button'; // Button 컴포넌트 사용을 위해 import
 
+// 1. props 타입에 isLoading, isError 추가
 type AddMemberModalProps = {
   onClose?: () => void;
   tripCode: string | undefined;
+  isLoading: boolean;
+  isError: boolean;
 };
 
-const AddMemberModal = ({ onClose, tripCode }: AddMemberModalProps) => {
+// 2. 컴포넌트가 받을 props에 isLoading, isError 추가
+const AddMemberModal = ({ onClose, tripCode, isLoading, isError }: AddMemberModalProps) => {
   const y = useMotionValue(0);
   const controls = useDragControls();
 
   const handleCopy = async () => {
+    if (!tripCode) return; // tripCode가 없을 때 복사 방지
     try {
-      if (!tripCode) {
-        alert('초대 코드가 아직 준비되지 않았습니다. 새로고침 후 다시 시도해 주세요.');
-        return;
-      }
       await navigator.clipboard.writeText(tripCode);
       alert('코드가 복사되었습니다!');
     } catch (err) {
@@ -29,10 +31,38 @@ const AddMemberModal = ({ onClose, tripCode }: AddMemberModalProps) => {
 
   const animateAndClose = async () => {
     await animate(y, 500, { type: 'tween', duration: 0.2, ease: 'easeIn' });
-
     if (onClose) {
       onClose();
     }
+  };
+
+  // 3. 로딩/에러/성공 상태에 따라 다른 UI를 보여주는 내부 렌더링 함수
+  const renderContent = () => {
+    if (isLoading) {
+      return <div className="flex-1 flex items-center justify-center text-grey-550">초대 코드를 불러오는 중...</div>;
+    }
+
+    if (isError) {
+      return (
+        <div className="flex-1 flex items-center justify-center text-status_error">
+          코드를 불러오는 데 실패했습니다.
+        </div>
+      );
+    }
+
+    if (tripCode) {
+      return (
+        <>
+          <div className="flex pb-3 flex-col gap-1 items-center justify-center">
+            <label className="text-grey-550 text-body-2">초대 코드</label>
+            <p className="text-title-1 py-2">{tripCode}</p>
+          </div>
+          <Button label="복사하기" onClick={handleCopy} />
+        </>
+      );
+    }
+
+    return null; // 데이터가 없는 비정상적인 경우
   };
 
   return (
@@ -42,22 +72,18 @@ const AddMemberModal = ({ onClose, tripCode }: AddMemberModalProps) => {
       animate={{ y: 0 }}
       exit={{ y: '100%' }}
       transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-      className="w-full h-[200px] bg-white rounded-t-[20px] px-5 pb-8 flex flex-col items-center justify-center"
+      // 모달의 기본 높이를 auto로 설정하여 내용에 맞게 조절되도록 합니다.
+      className="w-full min-h-[200px] bg-white rounded-t-[20px] px-5 pb-8 flex flex-col items-center"
       drag="y"
       dragListener={false}
       dragControls={controls}
       onDrag={(e, info) => {
-        if (info.offset.y > 0) {
-          // 하단 스크롤만 가능
-          y.set(info.offset.y);
-        } else {
-          // 상단 스크롤 제한
-          y.set(0);
-        }
+        if (info.offset.y > 0) y.set(info.offset.y);
+        else y.set(0);
       }}
       onDragEnd={() => {
-        const currentY = y.get();
-        if (currentY > 10) {
+        if (y.get() > 50) {
+          // 드래그 민감도를 조금 낮춤
           animateAndClose();
         } else {
           animate(y, 0, { type: 'spring', stiffness: 300, damping: 30 });
@@ -65,22 +91,13 @@ const AddMemberModal = ({ onClose, tripCode }: AddMemberModalProps) => {
       }}
     >
       <div
-        className="flex w-full flex-1 justify-center py-3 cursor-grab active:cursor-grabbing"
+        className="flex w-full justify-center py-3 cursor-grab active:cursor-grabbing"
         onPointerDown={(e) => controls.start(e)}
       >
         <Image src={grabber} alt="handle modal" />
       </div>
 
-      <div className="flex pb-3 flex-col gap-1 items-center justify-center">
-        <label className="text-grey-550 text-body-2">초대 코드</label>
-        <p className="text-title-1 py-2">{tripCode}</p>
-      </div>
-      <button
-        onClick={handleCopy}
-        className="min-w-[320px] cursor-pointer max-w-[375px] w-full lg:max-w-[360px] mx-auto py-[14px] bg-primary rounded-xl flex justify-center items-center"
-      >
-        <div className="text-white text-label-1">복사하기</div>
-      </button>
+      {renderContent()}
     </motion.div>
   );
 };

--- a/snapsplit/src/features/trip/[tripId]/types/trip-type.ts
+++ b/snapsplit/src/features/trip/[tripId]/types/trip-type.ts
@@ -1,0 +1,3 @@
+export interface GetTripCodeDto {
+    tripCode: string;
+}

--- a/snapsplit/src/shared/components/TripHeader.tsx
+++ b/snapsplit/src/shared/components/TripHeader.tsx
@@ -13,6 +13,9 @@ import BottomSheet from './bottom-sheet/BottomSheet';
 import close from '@public/svg/close-grey-550.svg';
 import Button from '@/shared/components/Button';
 
+import { getTripCodeData } from '@trip/[tripId]/api/trip-api';
+import { useQuery } from '@tanstack/react-query';
+
 // 케밥 메뉴 바텀 시트
 interface KebabMenuBottomSheetProps {
   onCloseMenu: () => void;
@@ -77,11 +80,29 @@ type TripHeaderProps = {
   tripId: string;
 };
 
-// 여행 공통 헤더
 const TripHeader = ({ tripId }: TripHeaderProps) => {
   const [isAddMemberModalOpen, setIsAddMemberModalOpen] = useState(false);
   const [isMenuModalOpen, setIsMenuModalOpen] = useState(false);
   const [isDeleteTripModalOpen, setIsDeleteTripModalOpen] = useState(false);
+
+  // 데이터 페칭
+  const {
+    data: tripCodeData,
+    isLoading,
+    isError,
+    error,
+  } = useQuery({
+    queryKey: ['tripCode', tripId],
+    queryFn: () => getTripCodeData(tripId),
+  });
+
+  if (isLoading) {
+    return <div>로딩 중...</div>;
+  }
+
+  if (isError) {
+    return <div>에러가 발생했습니다: {error.message}</div>;
+  }
 
   return (
     <>
@@ -106,7 +127,7 @@ const TripHeader = ({ tripId }: TripHeaderProps) => {
 
       {/* 동행 추가 바텀시트 */}
       <OverlayModal isOpen={isAddMemberModalOpen} onClose={() => setIsAddMemberModalOpen(false)} position="bottom">
-        <AddMemberModal onClose={() => setIsAddMemberModalOpen(false)} />
+        <AddMemberModal onClose={() => setIsAddMemberModalOpen(false)} tripCode={tripCodeData?.tripCode} />
       </OverlayModal>
 
       {/* 케밥 메뉴 바텀시트 */}

--- a/snapsplit/src/shared/constants/apipath.ts
+++ b/snapsplit/src/shared/constants/apipath.ts
@@ -6,4 +6,5 @@ export const enum apiPath {
   users = "/users/code",
   budget = "/trips/{tripId}/expenses",
   trips = "/trips",
+  tripCode = "/trips/{tripId}/tripcode"
 }


### PR DESCRIPTION
## ✨ 개요  
- 여행 코드 조회 API 연동

## ✅ 세부 내용
- API는 [tripId] 내부에 구현
- tanstack Query 적용
<img width="420" height="151" alt="image" src="https://github.com/user-attachments/assets/13a246b7-bb79-4c5c-8510-51973dfadbb0" />

## 추후 구현 내용
- 스켈레톤 적용

---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 여행 화면에서 초대코드를 서버에서 자동으로 불러와 헤더와 구성원 추가 모달에 연결합니다.
  * 모달에서 실제 초대코드를 바로 확인하고 원클릭으로 클립보드에 복사할 수 있습니다.
  * 데이터 로딩 중에는 진행 상태가, 오류 발생 시에는 에러 메시지가 표시되어 상황 파악과 대응이 쉬워졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->