### PR TITLE
[Feat] SNAP 페이지 - 얼굴 등록 UI 개발

### DIFF
--- a/snapsplit/package.json
+++ b/snapsplit/package.json
@@ -9,8 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "axios": "^1.11.0",
     "@tanstack/react-query": "^5.84.0",
+    "axios": "^1.11.0",
+    "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "framer-motion": "^12.17.3",

--- a/snapsplit/pnpm-lock.yaml
+++ b/snapsplit/pnpm-lock.yaml
@@ -5,12 +5,15 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
-  axios:
-    specifier: ^1.11.0
-    version: 1.11.0
   '@tanstack/react-query':
     specifier: ^5.84.0
     version: 5.84.0(react@19.1.0)
+  axios:
+    specifier: ^1.11.0
+    version: 1.11.0
+  clsx:
+    specifier: ^2.1.1
+    version: 2.1.1
   date-fns:
     specifier: ^4.1.0
     version: 4.1.0
@@ -1353,6 +1356,11 @@ packages:
 
   /client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+    dev: false
+
+  /clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
     dev: false
 
   /color-convert@2.0.1:

--- a/snapsplit/src/app/(with-gnb)/trip/[tripId]/snap/face-test/page.tsx
+++ b/snapsplit/src/app/(with-gnb)/trip/[tripId]/snap/face-test/page.tsx
@@ -1,0 +1,7 @@
+import FaceTestPage from '@/features/trip/[tripId]/snap/face-test/FaceTestPage';
+
+export default async function FaceTest({ params }: { params: Promise<{ tripId: string }> }) {
+  const { tripId } = await params;
+
+  return <FaceTestPage tripId={tripId} />;
+}

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import { useState, useRef } from 'react';
 import TabSelector from '@/features/trip/[tripId]/snap/_components/TabSelector';
 import UploadButton from '@/features/trip/[tripId]/snap/_components/UploadButton';
@@ -8,6 +9,8 @@ import { ActiveTab } from '@/features/trip/[tripId]/snap/type';
 import FloatingModal from '@/shared/components/modal/FloatingModal';
 import TripHeader from '@/shared/components/TripHeader';
 import TripInfo from '../../budget/_components/TripInfo';
+
+import clsx from 'clsx';
 
 const tripInfo = {
   tripName: '스냅스플릿 연구팟',
@@ -29,13 +32,33 @@ type MemberData = {
   name: string;
   profileImageUrl?: string;
   hasFaceData: boolean;
+  isCurrentUser: boolean;
 };
 
-const FaceEnrollButton = ({}) => {
+type FaceEnrollButtonProps = {
+  hasFaceData?: boolean;
+  isCurrentUser?: boolean;
+};
+
+const FaceEnrollButton = ({ hasFaceData, isCurrentUser }: FaceEnrollButtonProps) => {
   return (
     <button className="flex cursor-pointer whitespace-nowrap items-center justify-center w-16 h-7 text-body-2 text-white bg-primary rounded-lg">
       등록하기
     </button>
+  );
+};
+
+const EnrollmentMemberItem = ({ member }: { member: MemberData }) => {
+  return (
+    <div key={member.memberId} className="flex items-center justify-between">
+      <div className="flex items-center justify-center gap-3">
+        <div className="w-10 h-10 bg-grey-450 rounded-full"></div>
+        <span className="text-body-1 whitespace-nowrap text-grey-850">
+          {member.isCurrentUser ? '(나)' : member.name}
+        </span>
+      </div>
+      <FaceEnrollButton />
+    </div>
   );
 };
 
@@ -50,13 +73,7 @@ const FaceEnrollmentSection = ({ members }: FaceEnrollmentSectionProps) => {
       <span className="text-grey-450 text-label-1 pb-10">SNAP 기능을 사용할 수 있어요!</span>
       <div className="space-y-5 bg-white rounded-2xl p-5 max-h-72 overflow-y-auto scrollbar-hide">
         {members.map((member) => (
-          <div key={member.memberId} className="flex items-center justify-between">
-            <div className="flex items-center justify-center gap-3">
-              <div className="w-10 h-10 bg-grey-450 rounded-full"></div>
-              <span className="text-body-1 whitespace-nowrap text-grey-850">{member.name}</span>
-            </div>
-            <FaceEnrollButton />
-          </div>
+          <EnrollmentMemberItem key={member.memberId} member={member} />
         ))}
       </div>
     </div>
@@ -93,12 +110,11 @@ export default function FaceTestPage({ tripId }: SnapPageProps) {
       {!isAllMemberHasFace ? (
         <FaceEnrollmentSection
           members={[
-            { memberId: 1, name: '김연아', profileImageUrl: 'https://i.pravatar.cc/150?img=1', hasFaceData: false },
-            { memberId: 2, name: '박지성', profileImageUrl: 'https://i.pravatar.cc/150?img=2', hasFaceData: false },
-            { memberId: 3, name: '손흥민', profileImageUrl: '', hasFaceData: false },
-            { memberId: 4, name: '김민재', profileImageUrl: '', hasFaceData: false },
-            { memberId: 5, name: '황희찬', profileImageUrl: '', hasFaceData: false },
-            { memberId: 6, name: '이강인', profileImageUrl: '', hasFaceData: false },
+            { memberId: 1, name: '김스냅', hasFaceData: true, isCurrentUser: true },
+            { memberId: 2, name: '이스플릿', hasFaceData: false, isCurrentUser: false },
+            { memberId: 3, name: '박연구', hasFaceData: false, isCurrentUser: false },
+            { memberId: 4, name: '최테스트', hasFaceData: false, isCurrentUser: false },
+            { memberId: 5, name: '정개발', hasFaceData: false, isCurrentUser: false },
           ]}
         />
       ) : activeTab === '전체' ? (

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
@@ -42,8 +42,15 @@ type FaceEnrollButtonProps = {
 
 const FaceEnrollButton = ({ hasFaceData, isCurrentUser }: FaceEnrollButtonProps) => {
   return (
-    <button className="flex cursor-pointer whitespace-nowrap items-center justify-center w-16 h-7 text-body-2 text-white bg-primary rounded-lg">
-      등록하기
+    <button
+      disabled={hasFaceData || !isCurrentUser}
+      className={clsx('flex items-center justify-center w-16 h-7 rounded-lg text-body-2', {
+        'bg-white text-grey-450 border border-grey-250': hasFaceData,
+        'bg-primary text-white': !hasFaceData && isCurrentUser,
+        'bg-grey-350 text-white': !hasFaceData && !isCurrentUser,
+      })}
+    >
+      {hasFaceData ? '등록완료' : isCurrentUser ? '등록하기' : '미등록'}
     </button>
   );
 };
@@ -57,7 +64,7 @@ const EnrollmentMemberItem = ({ member }: { member: MemberData }) => {
           {member.isCurrentUser ? '(나)' : member.name}
         </span>
       </div>
-      <FaceEnrollButton />
+      <FaceEnrollButton hasFaceData={member.hasFaceData} isCurrentUser={member.isCurrentUser} />
     </div>
   );
 };
@@ -110,9 +117,9 @@ export default function FaceTestPage({ tripId }: SnapPageProps) {
       {!isAllMemberHasFace ? (
         <FaceEnrollmentSection
           members={[
-            { memberId: 1, name: '김스냅', hasFaceData: true, isCurrentUser: true },
-            { memberId: 2, name: '이스플릿', hasFaceData: false, isCurrentUser: false },
-            { memberId: 3, name: '박연구', hasFaceData: false, isCurrentUser: false },
+            { memberId: 1, name: '김스냅', hasFaceData: false, isCurrentUser: true },
+            { memberId: 2, name: '이스플릿', hasFaceData: true, isCurrentUser: false },
+            { memberId: 3, name: '박연구', hasFaceData: true, isCurrentUser: false },
             { memberId: 4, name: '최테스트', hasFaceData: false, isCurrentUser: false },
             { memberId: 5, name: '정개발', hasFaceData: false, isCurrentUser: false },
           ]}

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
@@ -24,6 +24,45 @@ type SnapPageProps = {
   tripId: string;
 };
 
+type MemberData = {
+  memberId: number;
+  name: string;
+  profileImageUrl?: string;
+  hasFaceData: boolean;
+};
+
+const FaceEnrollButton = ({}) => {
+  return (
+    <button className="flex cursor-pointer whitespace-nowrap items-center justify-center w-16 h-7 text-body-2 text-white bg-primary rounded-lg">
+      등록하기
+    </button>
+  );
+};
+
+type FaceEnrollmentSectionProps = {
+  members: MemberData[];
+};
+
+const FaceEnrollmentSection = ({ members }: FaceEnrollmentSectionProps) => {
+  return (
+    <div className="flex flex-col h-full w-full itesm-center justify-center text-center p-10 pb-40">
+      <span className="text-grey-450 text-label-1">전원 얼굴 등록 이후</span>
+      <span className="text-grey-450 text-label-1 pb-10">SNAP 기능을 사용할 수 있어요!</span>
+      <div className="space-y-5 bg-white rounded-2xl p-5 max-h-72 overflow-y-auto scrollbar-hide">
+        {members.map((member) => (
+          <div key={member.memberId} className="flex items-center justify-between">
+            <div className="flex items-center justify-center gap-3">
+              <div className="w-10 h-10 bg-grey-450 rounded-full"></div>
+              <span className="text-body-1 whitespace-nowrap text-grey-850">{member.name}</span>
+            </div>
+            <FaceEnrollButton />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
 export default function FaceTestPage({ tripId }: SnapPageProps) {
   const isAllMemberHasFace = false;
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -51,8 +90,18 @@ export default function FaceTestPage({ tripId }: SnapPageProps) {
       </div>
       <TabSelector activeTab={activeTab} setActiveTab={setActiveTab} />
 
-      {/* 컨텐츠 영역 */}
-      {activeTab === '전체' ? (
+      {!isAllMemberHasFace ? (
+        <FaceEnrollmentSection
+          members={[
+            { memberId: 1, name: '김연아', profileImageUrl: 'https://i.pravatar.cc/150?img=1', hasFaceData: false },
+            { memberId: 2, name: '박지성', profileImageUrl: 'https://i.pravatar.cc/150?img=2', hasFaceData: false },
+            { memberId: 3, name: '손흥민', profileImageUrl: '', hasFaceData: false },
+            { memberId: 4, name: '김민재', profileImageUrl: '', hasFaceData: false },
+            { memberId: 5, name: '황희찬', profileImageUrl: '', hasFaceData: false },
+            { memberId: 6, name: '이강인', profileImageUrl: '', hasFaceData: false },
+          ]}
+        />
+      ) : activeTab === '전체' ? (
         <BaseTabView setIsScrolled={setIsScrolled} setScrollToTop={setScrollToTop} />
       ) : (
         <FolderTabView />
@@ -70,11 +119,6 @@ export default function FaceTestPage({ tripId }: SnapPageProps) {
           if (file) alert(`파일 선택됨: ${file.name}`);
         }}
       />
-
-      {/* <div className="flex flex-col itesm-center justify-center">
-        <span>모든 멤버가 등록해야</span>
-        <span>SNAP 기능을 사용할 수 있어요!</span>
-      </div> */}
     </div>
   );
 }

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
@@ -9,8 +9,7 @@ import { ActiveTab } from '@/features/trip/[tripId]/snap/type';
 import FloatingModal from '@/shared/components/modal/FloatingModal';
 import TripHeader from '@/shared/components/TripHeader';
 import TripInfo from '../../budget/_components/TripInfo';
-
-import clsx from 'clsx';
+import { EnrollmentMemberItem } from './_components/EnrollmentMemberItem';
 
 const tripInfo = {
   tripName: '스냅스플릿 연구팟',
@@ -27,46 +26,13 @@ type SnapPageProps = {
   tripId: string;
 };
 
-type MemberData = {
+// SNAP 페이지에서 추가로 필요한 멤버 데이터 타입
+export type MemberData = {
   memberId: number;
   name: string;
   profileImageUrl?: string;
   hasFaceData: boolean;
   isCurrentUser: boolean;
-};
-
-type FaceEnrollButtonProps = {
-  hasFaceData?: boolean;
-  isCurrentUser?: boolean;
-};
-
-const FaceEnrollButton = ({ hasFaceData, isCurrentUser }: FaceEnrollButtonProps) => {
-  return (
-    <button
-      disabled={hasFaceData || !isCurrentUser}
-      className={clsx('flex items-center justify-center w-16 h-7 rounded-lg text-body-2', {
-        'bg-white text-grey-450 border border-grey-250': hasFaceData,
-        'bg-primary text-white': !hasFaceData && isCurrentUser,
-        'bg-grey-350 text-white': !hasFaceData && !isCurrentUser,
-      })}
-    >
-      {hasFaceData ? '등록완료' : isCurrentUser ? '등록하기' : '미등록'}
-    </button>
-  );
-};
-
-const EnrollmentMemberItem = ({ member }: { member: MemberData }) => {
-  return (
-    <div key={member.memberId} className="flex items-center justify-between">
-      <div className="flex items-center justify-center gap-3">
-        <div className="w-10 h-10 bg-grey-450 rounded-full"></div>
-        <span className="text-body-1 whitespace-nowrap text-grey-850">
-          {member.isCurrentUser ? '(나)' : member.name}
-        </span>
-      </div>
-      <FaceEnrollButton hasFaceData={member.hasFaceData} isCurrentUser={member.isCurrentUser} />
-    </div>
-  );
 };
 
 type FaceEnrollmentSectionProps = {
@@ -115,6 +81,7 @@ export default function FaceTestPage({ tripId }: SnapPageProps) {
       <TabSelector activeTab={activeTab} setActiveTab={setActiveTab} />
 
       {!isAllMemberHasFace ? (
+        // 추가한 코드
         <FaceEnrollmentSection
           members={[
             { memberId: 1, name: '김스냅', hasFaceData: false, isCurrentUser: true },
@@ -124,7 +91,8 @@ export default function FaceTestPage({ tripId }: SnapPageProps) {
             { memberId: 5, name: '정개발', hasFaceData: false, isCurrentUser: false },
           ]}
         />
-      ) : activeTab === '전체' ? (
+      ) : // 추가한 코드 끝
+      activeTab === '전체' ? (
         <BaseTabView setIsScrolled={setIsScrolled} setScrollToTop={setScrollToTop} />
       ) : (
         <FolderTabView />

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
@@ -44,10 +44,15 @@ const FaceEnrollmentSection = ({ members }: FaceEnrollmentSectionProps) => {
     <div className="flex flex-col h-full w-full itesm-center justify-center text-center p-10 pb-40">
       <span className="text-grey-450 text-label-1">전원 얼굴 등록 이후</span>
       <span className="text-grey-450 text-label-1 pb-10">SNAP 기능을 사용할 수 있어요!</span>
-      <div className="space-y-5 bg-white rounded-2xl p-5 max-h-72 overflow-y-auto scrollbar-hide">
-        {members.map((member) => (
-          <EnrollmentMemberItem key={member.memberId} member={member} />
-        ))}
+      <div className="relative">
+        <div className="space-y-5 bg-white rounded-2xl p-5 max-h-72 overflow-y-auto scrollbar-hide">
+          {members.map((m) => (
+            <EnrollmentMemberItem key={m.memberId} member={m} />
+          ))}
+        </div>
+        {/* 상/하 스크롤 힌트 그라데이션 */}
+        <div className="pointer-events-none absolute top-0 left-0 right-0 h-4 bg-gradient-to-b from-white to-transparent rounded-t-2xl" />
+        <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-4 bg-gradient-to-t from-white to-transparent rounded-b-2xl" />
       </div>
     </div>
   );
@@ -88,7 +93,10 @@ export default function FaceTestPage({ tripId }: SnapPageProps) {
             { memberId: 2, name: '이스플릿', hasFaceData: true, isCurrentUser: false },
             { memberId: 3, name: '박연구', hasFaceData: true, isCurrentUser: false },
             { memberId: 4, name: '최테스트', hasFaceData: false, isCurrentUser: false },
-            { memberId: 5, name: '정개발', hasFaceData: false, isCurrentUser: false },
+            { memberId: 5, name: '홍길동', hasFaceData: false, isCurrentUser: false },
+            { memberId: 6, name: '고길동', hasFaceData: true, isCurrentUser: false },
+            { memberId: 7, name: '장길동', hasFaceData: false, isCurrentUser: false },
+            { memberId: 8, name: '임꺽정', hasFaceData: true, isCurrentUser: false },
           ]}
         />
       ) : // 추가한 코드 끝

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/FaceTestPage.tsx
@@ -1,0 +1,80 @@
+'use client';
+import { useState, useRef } from 'react';
+import TabSelector from '@/features/trip/[tripId]/snap/_components/TabSelector';
+import UploadButton from '@/features/trip/[tripId]/snap/_components/UploadButton';
+import BaseTabView from '@/features/trip/[tripId]/snap/_components/tabView/BaseTabView';
+import FolderTabView from '@/features/trip/[tripId]/snap/_components/tabView/FolderTabView';
+import { ActiveTab } from '@/features/trip/[tripId]/snap/type';
+import FloatingModal from '@/shared/components/modal/FloatingModal';
+import TripHeader from '@/shared/components/TripHeader';
+import TripInfo from '../../budget/_components/TripInfo';
+
+const tripInfo = {
+  tripName: '스냅스플릿 연구팟',
+  countries: [
+    { countryId: 1, countryName: '런던' },
+    { countryId: 2, countryName: '파리' },
+    { countryId: 3, countryName: '취리히' },
+  ],
+  startDate: '2025.4.7',
+  endDate: '4.12',
+};
+
+type SnapPageProps = {
+  tripId: string;
+};
+
+export default function FaceTestPage({ tripId }: SnapPageProps) {
+  const isAllMemberHasFace = false;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [activeTab, setActiveTab] = useState<ActiveTab>('전체');
+  const [isScrolled, setIsScrolled] = useState(false);
+  const [scrollToTop, setScrollToTop] = useState<(() => void) | null>(null);
+
+  return (
+    <div className="flex flex-col h-screen bg-light_grey">
+      <div className="bg-white">
+        <TripHeader tripId={tripId} />
+        {isScrolled && (
+          <div className="px-5">
+            <span className="text-label-1">{tripInfo.tripName}</span>
+          </div>
+        )}
+        {!isScrolled && (
+          <TripInfo
+            tripName={tripInfo.tripName}
+            countries={tripInfo.countries.map((c) => c.countryName)}
+            startDate={tripInfo.startDate}
+            endDate={tripInfo.endDate}
+          />
+        )}
+      </div>
+      <TabSelector activeTab={activeTab} setActiveTab={setActiveTab} />
+
+      {/* 컨텐츠 영역 */}
+      {activeTab === '전체' ? (
+        <BaseTabView setIsScrolled={setIsScrolled} setScrollToTop={setScrollToTop} />
+      ) : (
+        <FolderTabView />
+      )}
+      <FloatingModal>
+        <UploadButton isScrolled={isScrolled} inputRef={fileInputRef} scrollToTop={scrollToTop} />
+      </FloatingModal>
+      <input
+        type="file"
+        accept="image/*"
+        ref={fileInputRef}
+        style={{ display: 'none' }}
+        onChange={(e) => {
+          const file = e.target.files?.[0];
+          if (file) alert(`파일 선택됨: ${file.name}`);
+        }}
+      />
+
+      {/* <div className="flex flex-col itesm-center justify-center">
+        <span>모든 멤버가 등록해야</span>
+        <span>SNAP 기능을 사용할 수 있어요!</span>
+      </div> */}
+    </div>
+  );
+}

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/EnrollmentMemberItem.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/EnrollmentMemberItem.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import { MemberData } from '../FaceTestPage';
 import { FaceEnrollButton } from './FaceEnrollButton';
 
@@ -5,7 +6,19 @@ export const EnrollmentMemberItem = ({ member }: { member: MemberData }) => {
   return (
     <div key={member.memberId} className="flex items-center justify-between">
       <div className="flex items-center justify-center gap-3">
-        <div className="w-10 h-10 bg-grey-450 rounded-full"></div>
+        <div className="relative w-10 h-10">
+          {/* 프로필 이미지 */}
+          <div
+            className={clsx('w-10 h-10 bg-grey-450 rounded-full', { 'border border-primary': member.isCurrentUser })}
+          />
+          {/* 체크 아이콘 */}
+          {member.hasFaceData && (
+            <div className="absolute -bottom-1 -right-1 w-4 h-4 flex items-center justify-center rounded-full bg-primary text-white text-[10px]">
+              ✓
+            </div>
+          )}
+        </div>
+
         <span className="text-body-1 whitespace-nowrap text-grey-850">
           {member.isCurrentUser ? '(나)' : member.name}
         </span>

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/EnrollmentMemberItem.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/EnrollmentMemberItem.tsx
@@ -1,0 +1,16 @@
+import { MemberData } from '../FaceTestPage';
+import { FaceEnrollButton } from './FaceEnrollButton';
+
+export const EnrollmentMemberItem = ({ member }: { member: MemberData }) => {
+  return (
+    <div key={member.memberId} className="flex items-center justify-between">
+      <div className="flex items-center justify-center gap-3">
+        <div className="w-10 h-10 bg-grey-450 rounded-full"></div>
+        <span className="text-body-1 whitespace-nowrap text-grey-850">
+          {member.isCurrentUser ? '(나)' : member.name}
+        </span>
+      </div>
+      <FaceEnrollButton hasFaceData={member.hasFaceData} isCurrentUser={member.isCurrentUser} />
+    </div>
+  );
+};

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/FaceEnrollButton.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/FaceEnrollButton.tsx
@@ -10,7 +10,7 @@ export const FaceEnrollButton = ({ hasFaceData, isCurrentUser }: FaceEnrollButto
     <button
       disabled={hasFaceData || !isCurrentUser}
       className={
-        clsx('flex items-center justify-center w-16 h-7 rounded-lg text-body-2', {
+        clsx('flex items-center justify-center min-w-16 h-7 rounded-lg text-body-2', {
           'bg-white text-grey-450 border border-grey-250': hasFaceData,
           'bg-primary text-white': !hasFaceData && isCurrentUser,
           'bg-grey-350 text-white': !hasFaceData && !isCurrentUser,

--- a/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/FaceEnrollButton.tsx
+++ b/snapsplit/src/features/trip/[tripId]/snap/face-test/_components/FaceEnrollButton.tsx
@@ -1,0 +1,24 @@
+import clsx from 'clsx';
+
+export type FaceEnrollButtonProps = {
+  hasFaceData?: boolean;
+  isCurrentUser?: boolean;
+};
+
+export const FaceEnrollButton = ({ hasFaceData, isCurrentUser }: FaceEnrollButtonProps) => {
+  return (
+    <button
+      disabled={hasFaceData || !isCurrentUser}
+      className={
+        clsx('flex items-center justify-center w-16 h-7 rounded-lg text-body-2', {
+          'bg-white text-grey-450 border border-grey-250': hasFaceData,
+          'bg-primary text-white': !hasFaceData && isCurrentUser,
+          'bg-grey-350 text-white': !hasFaceData && !isCurrentUser,
+        })
+        // 버튼 클릭 시 얼굴 등록 페이지로 이동
+      }
+    >
+      {hasFaceData ? '등록완료' : isCurrentUser ? '등록하기' : '미등록'}
+    </button>
+  );
+};

--- a/snapsplit/src/shared/components/TripHeader.tsx
+++ b/snapsplit/src/shared/components/TripHeader.tsx
@@ -128,7 +128,7 @@ const TripHeader = ({ tripId }: TripHeaderProps) => {
 
         <div className="flex flex-row space-x-3 items-center justify-center">
           <button
-            className="flex flex-row rounded-[20px] border-1 p-[2px] pr-2 cursor-pointer text-sm items-center justify-center"
+            className="flex flex-row rounded-[20px] border-[1.5px] p-[2px] pr-2 cursor-pointer text-sm items-center justify-center"
             onClick={() => setIsAddMemberModalOpen(true)}
           >
             <Image src={plus3Black} alt="동행추가" />


### PR DESCRIPTION
## ✨ 개요
- SNAP 페이지 - 얼굴 등록 UI 개발

## ✅ 세부 내용
### UI/UX 로직 설명
해당 멤버가 현재 로그인한 사용자인지 판별 여부에 따라 UI 변동 사항 있
이 정보 또한 프론트에서 포함해야 합니다.

- 멤버가 “현재 로그인한 사용자”일 시
    1. 맨 위에 랜더링
    2. 멤버 이름 “나” 로 표시
    3. 얼굴 등록 여부 {false} 일 시 primary 컬러 버튼 랜더링

## 💻 구현 화면
<img width="402" height="933" alt="image" src="https://github.com/user-attachments/assets/29f02b7a-c426-406d-a900-7485c596b094" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 여행 SNAP의 얼굴 등록 테스트 페이지 추가: 스크롤 반응형 헤더, 탭 전환, 업로드 모달과 파일 선택 지원.
  - 멤버별 등록 상태 표시 및 상태에 따른 버튼 라벨(등록완료/등록하기/미등록) 및 활성화 제어.

- 스타일
  - 상단 헤더의 “멤버 추가” 버튼 테두리 두께 미세 조정으로 시각적 일관성 개선.

- 작업
  - UI 상태 클래스 관리를 위한 경량 의존성 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->