### PR TITLE
[Fix] 코드로 여행 참가 - 에러 메세지 반영

### DIFF
--- a/snapsplit/src/features/home/_components/modal/JoinTripByCodeModal.tsx
+++ b/snapsplit/src/features/home/_components/modal/JoinTripByCodeModal.tsx
@@ -37,7 +37,6 @@ export default function JoinTripByCodeModal({ onClose }: JoinTripByCodeModalProp
         onClick={async () => {
           try {
             await joinTripByCode(code);
-            alert('여행에 성공적으로 참여했습니다!');
           } catch (error) {
             console.error('여행 참여 실패:', error);
           }

--- a/snapsplit/src/features/home/api/home-api.ts
+++ b/snapsplit/src/features/home/api/home-api.ts
@@ -11,15 +11,14 @@ export const getHomeData = async (): Promise<GetHomeResponseDto> => {
 };
 
 // 코드로 여행 참가
-export const joinTripByCode = async (code: string): Promise<void> => {
+export const joinTripByCode = async (inviteCode: string): Promise<void> => {
   try {
-    await privateInstance.post<ApiEnvelope<null>>(apiPath.joinTrip, { code });
+    await privateInstance.post<ApiEnvelope<null>>(apiPath.joinTrip, { inviteCode });
     alert('여행에 성공적으로 참여했습니다!');
     return;
   } catch (error) {
     // 4xx, 5xx 에러는 모두 여기서 처리합니다.
     if (axios.isAxiosError(error) && error.response?.data) {
-      console.log('서버 응답 데이터:', error.response.data);
       alert(error.response.data.message || '알 수 없는 서버 오류가 발생했습니다.');
       throw new Error(error.response.data.message || '알 수 없는 서버 오류가 발생했습니다.');
     }


### PR DESCRIPTION
<img width="562" height="621" alt="image" src="https://github.com/user-attachments/assets/9a295cfa-e1e7-4468-90a9-4c84cefd2e25" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 초대 코드로 여행 참가 시 알림 흐름을 정리하여 중복 알림을 제거했습니다.
  - 참가 성공 시 단일 성공 알림이 표시됩니다.
  - 실패 시 서버에서 제공하는 구체적인 오류 메시지를 알림으로 안내합니다.
  - 유효하지 않은 코드를 입력하면 참가 버튼이 비활성화되는 기존 동작을 유지합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->