### PR TITLE
[Fix] 지출 추가/수정 시 데이터 리페치

### DIFF
--- a/snapsplit/src/features/trip/[tripId]/budget/expense/_components/ExpenseForm.tsx
+++ b/snapsplit/src/features/trip/[tripId]/budget/expense/_components/ExpenseForm.tsx
@@ -17,7 +17,11 @@ import { useEffect, useState } from 'react';
 import { createExpense, createExpenseWithReceipt, getExpensePageData } from '../api/expense-api';
 import { useReceiptStore } from '@/lib/zustand/useReceiptStore';
 import ReceiptDetailSection from './expense-form/ReceiptDetailSection';
-import type { CreateExpenseRequest, CreateExpenseRequestWithReceipt, ExpensePageDataResponse } from '../api/expense-dto-type';
+import type {
+  CreateExpenseRequest,
+  CreateExpenseRequestWithReceipt,
+  ExpensePageDataResponse,
+} from '../api/expense-dto-type';
 import Loading from '@/shared/components/loading/Loading';
 import { useMutation, useQueryClient } from '@tanstack/react-query'; // ✅ useMutation 임포트
 
@@ -144,11 +148,10 @@ export default function ExpenseForm() {
     mutationFn: (refinedForm: CreateExpenseRequest) => createExpense(Number(tripId), refinedForm),
 
     onSuccess: async () => {
-      alert('지출이 성공적으로 등록되었습니다.');
       clearReceiptData();
 
       await queryClient.invalidateQueries({
-        queryKey: ['tripBudget', tripId],
+        queryKey: ['tripBudget', tripId], refetchType: 'active'
       });
 
       router.push(`/trip/${tripId}/budget`);
@@ -165,9 +168,8 @@ export default function ExpenseForm() {
     mutationFn: (refinedForm: CreateExpenseRequestWithReceipt) => createExpenseWithReceipt(Number(tripId), refinedForm),
 
     onSuccess: async () => {
-      alert('지출이 성공적으로 등록되었습니다.');
       clearReceiptData();
-      await queryClient.invalidateQueries({
+      await queryClient.refetchQueries({
         queryKey: ['tripBudget', tripId],
       });
 

--- a/snapsplit/src/features/trip/[tripId]/budget/expense/edit/ExpenseEditForm.tsx
+++ b/snapsplit/src/features/trip/[tripId]/budget/expense/edit/ExpenseEditForm.tsx
@@ -41,8 +41,7 @@ export default function ExpenseEditForm() {
   /* ───────────────────────────
    * 1) expenseDetail 가져오기 (캐시에서)
    * ─────────────────────────── */
-  const expenseDetail: ExpenseDetail | null =
-    queryClient.getQueryData(['expenseDetail', tripId, expenseId]) || null;
+  const expenseDetail: ExpenseDetail | null = queryClient.getQueryData(['expenseDetail', tripId, expenseId]) || null;
 
   const date = expenseDetail?.date ?? null;
 
@@ -146,13 +145,12 @@ export default function ExpenseEditForm() {
    * Mutation 적용
    * ─────────────────────────── */
   const { mutate: editExpenseMutate, isPending: isEditing } = useMutation({
-    mutationFn: (payload: CreateExpenseRequest) =>
-      editExpense(Number(tripId), Number(expenseId), payload),
+    mutationFn: (payload: CreateExpenseRequest) => editExpense(Number(tripId), Number(expenseId), payload),
 
     onSuccess: () => {
-      alert('지출이 성공적으로 수정되었습니다.');
-
-      queryClient.invalidateQueries({ queryKey: ['tripBudget', tripId] });
+      queryClient.refetchQueries({
+        queryKey: ['tripBudget', tripId],
+      });
 
       router.push(`/trip/${tripId}/budget`);
     },
@@ -163,14 +161,10 @@ export default function ExpenseEditForm() {
   });
 
   const { mutate: editExpenseWithReceiptMutate, isPending: isEditingWithReceipt } = useMutation({
-    mutationFn: (payload: CreateExpenseRequestWithReceipt) =>
-      editExpense(Number(tripId), Number(expenseId), payload),
+    mutationFn: (payload: CreateExpenseRequestWithReceipt) => editExpense(Number(tripId), Number(expenseId), payload),
 
     onSuccess: () => {
-      alert('지출이 성공적으로 수정되었습니다.');
-
-      queryClient.invalidateQueries({ queryKey: ['expenseDetail', tripId, expenseId] });
-      queryClient.invalidateQueries({ queryKey: ['tripBudget', tripId] });
+      queryClient.refetchQueries({ queryKey: ['tripBudget', tripId] });
 
       router.push(`/trip/${tripId}/budget`);
     },


### PR DESCRIPTION
## 상세
- 지출 추가/수정 시 Budget 페이지에서 refetch 필요한 데이터 있어서 처리 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 비용 생성 및 편집 시 성공 알림 제거
  * 캐시 새로고침 메커니즘 개선으로 데이터 동기화 최적화

* **개선사항**
  * 영수증 기반 및 비영수증 기반 비용 처리 흐름의 데이터 새로고침 성능 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->